### PR TITLE
Release v0.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ logs/
 .claude/worktrees/
 
 gha-creds-*.json
+
+# Per-project configs scaffolded by `tycoon init` / Recce
+# (this is the CLI source repo, not a tycoon project — keep these out)
+/tycoon.yml
+/recce.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project will be documented in this file. The format 
 - Option to register an existing dbt project by local path or GitHub URL during `tycoon init`; remote URLs are cloned into a sibling directory.
 - `TransformationTool` enum and `stack.transformation` field in `tycoon.yml` so "skip dbt" is a first-class, recorded choice (not an inferred state).
 - `tycoon doctor` now reports "skipped by choice" for components the user intentionally turned off during init, instead of warning about them.
+- **`tycoon register dbt <path-or-url>`** and **`tycoon register rill <path-or-url>`** — attach an existing dbt or Rill project to a tycoon.yml without re-running `tycoon init`. Supports local paths and GitHub URLs (with clone-on-register). Prompts before overwriting an already-registered component.
+- **Warehouse-alignment check**: when a registered dbt project targets a different DuckDB than tycoon's warehouse (via its `profiles.yml`), the wizard / `tycoon register dbt` warns and offers to adopt the dbt path — preventing the "dbt writes here, `tycoon data query` reads there" silent-divergence footgun.
+- Template smoke tests in the pytest suite: init + doctor validate cleanly for all four built-in templates (`csv-import`, `github-analytics`, `nyc-transit`, `weather-station`).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file. The format 
 - `tycoon doctor` no longer falsely claims that `tycoon data analyze` creates a missing dbt project; now directs users to `tycoon init` (or to point `dbt_project_dir` at an existing project).
 - `server/check-updates` now queries the correct PyPI package (`database-tycoon`) and uses `httpx` instead of `requests`.
 - `tycoon data transform` now falls back to `~/.dbt/profiles.yml` when a registered external dbt project has no co-located `profiles.yml`, instead of forcing `--profiles-dir` to the project root.
+- Fixed a crash in `tycoon data analyze` and `tycoon data sources run` when invoked without a source argument: the interactive "pick a source" prompt referenced `typer.Choice`, which doesn't exist at runtime. Now uses `click.Choice`. Regression test added.
 
 [0.1.1]: https://github.com/Database-Tycoon/tycoon-cli/releases/tag/v0.1.1
 [#1]: https://github.com/Database-Tycoon/tycoon-cli/issues/1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-04-16
+
+### Changed
+
+- Flattened `tycoon data db <sub>` into top-level `tycoon data <sub>`:
+  - `tycoon data db stats` → `tycoon data schema` (also reports any extra `.duckdb` files found in `data/`)
+  - `tycoon data db query` → `tycoon data query`
+  - `tycoon data db clean` → `tycoon data clean`
+- `tycoon init` (without `--template`) now runs a per-component wizard that walks through ingestion, warehouse, dbt, Rill, and orchestrator individually. Each prompt describes what tycoon will do for each option and explicitly includes "skip" where it makes sense.
+
+### Added
+
+- `tycoon data query --source <name>` — query a specific source's raw database, with auto-resolution between the shared `raw.duckdb` (single-DB mode) and per-source `data/raw_<name>.duckdb` files. Closes [#1].
+- `tycoon data query --db <path>` — query any DuckDB file directly.
+- `tycoon data analyze --rill` now scaffolds the Rill project directory on demand if it doesn't exist, instead of silently skipping.
+- `GET /health` endpoint on the internal server.
+- `tycoon init` auto-detects existing dbt and Rill projects in common inline locations (`./dbt_project/`, `./dbt/`, `./transformation/`, `./rill/`, `./dashboards/`) and in sibling directories (e.g. `../<name>-dbt/`), and offers them as an explicit "use this" option in the wizard.
+- Option to register an existing dbt project by local path or GitHub URL during `tycoon init`; remote URLs are cloned into a sibling directory.
+- `TransformationTool` enum and `stack.transformation` field in `tycoon.yml` so "skip dbt" is a first-class, recorded choice (not an inferred state).
+- `tycoon doctor` now reports "skipped by choice" for components the user intentionally turned off during init, instead of warning about them.
+
+### Fixed
+
+- `tycoon doctor` no longer falsely claims that `tycoon data analyze` creates a missing dbt project; now directs users to `tycoon init` (or to point `dbt_project_dir` at an existing project).
+- `server/check-updates` now queries the correct PyPI package (`database-tycoon`) and uses `httpx` instead of `requests`.
+- `tycoon data transform` now falls back to `~/.dbt/profiles.yml` when a registered external dbt project has no co-located `profiles.yml`, instead of forcing `--profiles-dir` to the project root.
+
+[0.1.1]: https://github.com/Database-Tycoon/tycoon-cli/releases/tag/v0.1.1
+[#1]: https://github.com/Database-Tycoon/tycoon-cli/issues/1
+
 ## [0.1.0] - 2026-04-09
 
 ### Added

--- a/docs/releases/v0.1.1.md
+++ b/docs/releases/v0.1.1.md
@@ -37,17 +37,50 @@ Two new flags solve the biggest reported v0.1.0 paper cut
   whether that's `data/raw.duckdb` (single-DB mode) or `data/raw_<name>.duckdb`.
 - `--db <path>` — queries any DuckDB file directly.
 
+### `tycoon register` — attach projects post-init
+
+Changed your mind after `tycoon init`? Two new subcommands let you attach
+an existing dbt or Rill project without re-running the wizard:
+
+```bash
+tycoon register dbt ../my-team-dbt/
+tycoon register dbt https://github.com/acme/analytics-dbt
+tycoon register rill ../dashboards/
+```
+
+GitHub URLs get cloned into a sibling dir. If you already had something
+registered, tycoon prompts before overwriting.
+
+### Warehouse alignment
+
+When you point tycoon at an external dbt project — either during
+`tycoon init` or via `tycoon register dbt` — tycoon now reads the project's
+`profiles.yml` and checks whether its DuckDB path matches tycoon's
+warehouse. If they diverge, you get an explicit prompt:
+
+> Your dbt project targets `/foo/theirs.duckdb`, but tycoon.yml has
+> warehouse = `data/warehouse.duckdb`. Update warehouse to
+> `/foo/theirs.duckdb`? [Y/n]
+
+No more silent "dbt wrote here, `tycoon data query` reads there" mystery
+mismatches.
+
 ## What changed
 
 ### Added
 
 - **Per-component init wizard** with auto-detection, register-existing (path
   or GitHub URL), and explicit "skip" support for every component.
+- **`tycoon register dbt`** and **`tycoon register rill`** — attach existing
+  projects to an existing `tycoon.yml` without re-running init.
+- **Warehouse-alignment check** when registering external dbt projects.
 - **`TransformationTool` enum** and new `stack.transformation` field in
   `tycoon.yml` — "skip dbt" is now recorded explicitly rather than inferred.
 - **`tycoon data query --source <name>`** and **`--db <path>`**.
 - **`tycoon data analyze --rill`** auto-scaffolds the Rill project dir
   instead of silently skipping when it's missing.
+- **Template smoke tests** for all four built-in templates
+  (`csv-import`, `github-analytics`, `nyc-transit`, `weather-station`).
 - **`GET /health`** endpoint on the internal server.
 
 ### Changed
@@ -91,9 +124,9 @@ see more prompts — five components, one at a time — and each has a visible
 
 ## What's next (v0.1.2 candidates)
 
-- Warehouse-alignment checks: when you register an external dbt project,
-  auto-pull the DuckDB path from its `profiles.yml` so `tycoon data query`
-  doesn't silently look in the wrong file.
-- `tycoon register <component>` companion command so you can add a dbt or
-  Rill project to an existing tycoon.yml without re-running init.
-- Smoke tests for more templates (github-analytics, csv-import) in CI.
+- Cloud-warehouse alignment: the same check we now do for DuckDB, but for
+  MotherDuck/Snowflake/BigQuery connection strings.
+- `tycoon register warehouse` / `tycoon register ingestion` — extend the
+  register family to cover the other stack components.
+- Network-gated end-to-end tests that run a full ingest → build → dashboard
+  cycle per template in CI.

--- a/docs/releases/v0.1.1.md
+++ b/docs/releases/v0.1.1.md
@@ -1,0 +1,99 @@
+# Tycoon v0.1.1
+
+_Released: 2026-04-16_
+
+Two themes in this release: **command cleanup** and a **real onboarding
+wizard** for `tycoon init`.
+
+## Headline
+
+### `tycoon init` now has a real wizard
+
+Running `tycoon init` without `--template` walks you through the stack one
+component at a time — ingestion, warehouse, dbt, Rill, orchestrator — and at
+each step tells you exactly what tycoon will do for each option.
+
+If you already have a dbt project at `./dbt_project/`, `../myproject-dbt/`,
+or any of the other common locations, the wizard offers it as an explicit
+"use this" option. If you have one in a GitHub repo somewhere, paste the
+URL and tycoon will clone it into a sibling directory. If you don't want
+dbt at all, "skip" is a first-class option and `tycoon doctor` will respect
+that choice rather than warning about it forever.
+
+### Commands flattened
+
+- `tycoon data db stats` → `tycoon data schema`
+- `tycoon data db query` → `tycoon data query`
+- `tycoon data db clean` → `tycoon data clean`
+
+Same functions, one level shallower. The `data db` namespace is gone.
+
+### `tycoon data query` knows about per-source databases
+
+Two new flags solve the biggest reported v0.1.0 paper cut
+([#1](https://github.com/Database-Tycoon/tycoon-cli/issues/1)):
+
+- `--source <name>` — queries the right raw DuckDB for a named source,
+  whether that's `data/raw.duckdb` (single-DB mode) or `data/raw_<name>.duckdb`.
+- `--db <path>` — queries any DuckDB file directly.
+
+## What changed
+
+### Added
+
+- **Per-component init wizard** with auto-detection, register-existing (path
+  or GitHub URL), and explicit "skip" support for every component.
+- **`TransformationTool` enum** and new `stack.transformation` field in
+  `tycoon.yml` — "skip dbt" is now recorded explicitly rather than inferred.
+- **`tycoon data query --source <name>`** and **`--db <path>`**.
+- **`tycoon data analyze --rill`** auto-scaffolds the Rill project dir
+  instead of silently skipping when it's missing.
+- **`GET /health`** endpoint on the internal server.
+
+### Changed
+
+- `tycoon data db <sub>` commands flattened (see above).
+- `tycoon doctor` reports "skipped by choice" for components the user
+  turned off during init.
+
+### Fixed
+
+- `tycoon doctor` no longer promises dbt will appear magically during
+  `tycoon data analyze` — it won't. That's `tycoon init`'s job.
+- `tycoon data transform` falls back to `~/.dbt/profiles.yml` when a
+  registered external dbt project has no co-located profiles file.
+- `server/check-updates` queries the right PyPI package
+  (`database-tycoon`) via `httpx`.
+
+## Upgrade notes
+
+```bash
+pip install -U database-tycoon
+```
+
+**Breaking for shell aliases:** the old `tycoon data db <sub>` paths are
+gone. Update aliases to the flattened form. No migration needed for
+`tycoon.yml`; the new `stack.transformation` field defaults to `dbt`, so
+existing configs keep working.
+
+**For anyone already using `tycoon init`:** the wizard is different. You'll
+see more prompts — five components, one at a time — and each has a visible
+"skip" option. If you use `--template`, that path is unchanged.
+
+## Known limitations (carried forward)
+
+- Snowflake and BigQuery: dbt can transform against them, but
+  `tycoon data query` is DuckDB-only for now.
+- External dlt pipelines can't be run via `tycoon data sources run` — only
+  tycoon-managed dlt sources are. The wizard reflects this: you can't
+  register an "external dlt" project because we have no way to run arbitrary
+  dlt scripts yet.
+
+## What's next (v0.1.2 candidates)
+
+- Warehouse-alignment checks: when you register an external dbt project,
+  auto-pull the DuckDB path from its `profiles.yml` so `tycoon data query`
+  doesn't silently look in the wrong file.
+- `tycoon register <component>` companion command so you can add a dbt or
+  Rill project to an existing tycoon.yml without re-running init.
+- Smoke tests for more templates (github-analytics, csv-import) in CI.

--- a/docs/releases/v0.1.1.md
+++ b/docs/releases/v0.1.1.md
@@ -97,6 +97,9 @@ mismatches.
   registered external dbt project has no co-located profiles file.
 - `server/check-updates` queries the right PyPI package
   (`database-tycoon`) via `httpx`.
+- `tycoon data analyze` and `tycoon data sources run` no longer crash with
+  `AttributeError` when invoked without a source argument — the interactive
+  "pick a source" prompt was using a non-existent `typer.Choice` reference.
 
 ## Upgrade notes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "database-tycoon"
-version = "0.1.0"
+version = "0.1.1"
 description = "Database Tycoon — local-first analytics CLI that adapts to your existing data stack"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/tycoon/__init__.py
+++ b/src/tycoon/__init__.py
@@ -1,3 +1,3 @@
 """Database Tycoon — local-first analytics CLI for exploring any dataset."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/tycoon/cli.py
+++ b/src/tycoon/cli.py
@@ -7,10 +7,11 @@ from typer.core import TyperGroup
 
 import tycoon
 
-_COMMAND_ORDER = ["init", "ask", "data", "start", "stop", "run", "doctor"]
+_COMMAND_ORDER = ["init", "register", "ask", "data", "start", "stop", "run", "doctor"]
 
 _SECTIONS = {
     "init":  "Project",
+    "register": "Project",
     "ask": "AI Analytics",
     "data":  "Data Pipeline",
     "start": "Services",
@@ -70,7 +71,7 @@ def _root(
     pass
 
 
-from tycoon.commands import ask, data
+from tycoon.commands import ask, data, register
 from tycoon.commands.doctor import doctor_cmd
 from tycoon.commands.init import init_cmd
 from tycoon.commands.run import run_cmd
@@ -78,6 +79,7 @@ from tycoon.commands.start import start_cmd
 from tycoon.commands.stop import stop_cmd
 
 app.command(name="init")(init_cmd)
+app.add_typer(register.app, name="register")
 app.add_typer(ask.app, name="ask")
 app.add_typer(data.app, name="data")
 app.command(name="start")(start_cmd)

--- a/src/tycoon/commands/data.py
+++ b/src/tycoon/commands/data.py
@@ -16,7 +16,9 @@ def _register() -> None:
 
     app.add_typer(sources.app, name="sources")
     app.add_typer(transform.app, name="transform")
-    app.add_typer(db.app, name="db")
+    app.command(name="query")(db.query)
+    app.command(name="schema")(db.schema)
+    app.command(name="clean")(db.clean)
     app.command(name="analyze")(analyze_cmd)
     app.command(name="run-all")(run_all_cmd)
     app.command(name="status")(status_cmd)

--- a/src/tycoon/commands/db.py
+++ b/src/tycoon/commands/db.py
@@ -14,50 +14,53 @@ from tycoon.utils.console import console, header, info, success, error, warn, st
 from tycoon.utils.duckdb_utils import db_file_size_mb, get_tables, get_row_count
 
 
-def _resolve_source_db(source_name: str) -> Path:
-    """Find the raw DuckDB file for a named source.
+def _resolve_source_db(source_name: str) -> Path | None:
+    """Find the raw DuckDB file for a named source, or None if not found.
 
-    Checks for the file at config.raw_db first (single-DB mode), then
-    looks for data/raw_{source_name}.duckdb and data/{prefix}_raw.duckdb
-    patterns in the data directory.
+    Priority:
+      1. ``config.raw_db``, if it contains the ``raw_<name>`` schema
+         (single-DB mode — current default for ``tycoon data sources run``).
+      2. ``data/raw_<name>.duckdb`` (canonical per-source filename).
+      3. Any other ``data/*.duckdb`` that contains the ``raw_<name>`` schema
+         (covers externally-loaded or alternatively-named files).
     """
-    # If config.raw_db exists and has a schema matching this source, use it
-    if config.raw_db.exists():
+    normalized = source_name.replace("-", "_")
+    source_schema = f"raw_{normalized}"
+
+    if config.raw_db.exists() and _has_schema(config.raw_db, source_schema):
+        return config.raw_db
+
+    per_source = config.data_dir / f"raw_{normalized}.duckdb"
+    if per_source.exists():
+        return per_source
+
+    if config.data_dir.exists():
+        skip = {config.raw_db.resolve(), per_source.resolve()}
+        for candidate in sorted(config.data_dir.glob("*.duckdb")):
+            if candidate.resolve() in skip:
+                continue
+            if _has_schema(candidate, source_schema):
+                return candidate
+
+    return None
+
+
+def _has_schema(db_path: Path, schema_name: str) -> bool:
+    """Return True if the DuckDB file contains the given schema."""
+    try:
+        con = duckdb.connect(str(db_path), read_only=True)
         try:
-            con = duckdb.connect(str(config.raw_db), read_only=True)
-            schemas = [r[0] for r in con.execute(
-                "SELECT DISTINCT schema_name FROM information_schema.schemata"
-            ).fetchall()]
+            schemas = [
+                r[0]
+                for r in con.execute(
+                    "SELECT DISTINCT schema_name FROM information_schema.schemata"
+                ).fetchall()
+            ]
+        finally:
             con.close()
-            source_schema = f"raw_{source_name.replace('-', '_')}"
-            if source_schema in schemas:
-                return config.raw_db
-        except duckdb.Error:
-            pass
-
-    # Look for per-source files in the data directory
-    data_dir = config.data_dir
-    if data_dir.exists():
-        for pattern in [
-            f"raw_{source_name.replace('-', '_')}.duckdb",
-            f"*_raw.duckdb",
-        ]:
-            matches = sorted(data_dir.glob(pattern))
-            for match in matches:
-                try:
-                    con = duckdb.connect(str(match), read_only=True)
-                    schemas = [r[0] for r in con.execute(
-                        "SELECT DISTINCT schema_name FROM information_schema.schemata"
-                    ).fetchall()]
-                    con.close()
-                    source_schema = f"raw_{source_name.replace('-', '_')}"
-                    if source_schema in schemas:
-                        return match
-                except duckdb.Error:
-                    continue
-
-    # Fallback: return the expected per-source path (caller will show error)
-    return data_dir / f"raw_{source_name.replace('-', '_')}.duckdb"
+    except duckdb.Error:
+        return False
+    return schema_name in schemas
 
 
 # ---------------------------------------------------------------------------
@@ -136,7 +139,12 @@ def query(
         db_path = db
         label = db_path.name
     elif source:
-        db_path = _resolve_source_db(source)
+        resolved = _resolve_source_db(source)
+        if resolved is None:
+            error(f"No raw database found for source '{source}'.")
+            info(f"Run 'tycoon data sources run {source}' to ingest data first.")
+            raise typer.Exit(1)
+        db_path = resolved
         label = f"raw ({source})"
     elif raw:
         db_path = config.raw_db
@@ -147,8 +155,6 @@ def query(
 
     if not db_path.exists():
         error(f"Database not found at {db_path}")
-        if source:
-            info(f"Run 'tycoon data sources run {source}' to ingest data first.")
         raise typer.Exit(1)
 
     try:

--- a/src/tycoon/commands/db.py
+++ b/src/tycoon/commands/db.py
@@ -1,4 +1,4 @@
-"""tycoon db — database inspection, querying, and cleanup."""
+"""tycoon data query / schema / clean — database inspection and querying."""
 
 from __future__ import annotations
 
@@ -13,41 +13,102 @@ from tycoon.config import config
 from tycoon.utils.console import console, header, info, success, error, warn, status_table
 from tycoon.utils.duckdb_utils import db_file_size_mb, get_tables, get_row_count
 
-app = typer.Typer(
-    help="Database inspection, querying, and cleanup.",
-    no_args_is_help=True,
-)
+
+def _resolve_source_db(source_name: str) -> Path:
+    """Find the raw DuckDB file for a named source.
+
+    Checks for the file at config.raw_db first (single-DB mode), then
+    looks for data/raw_{source_name}.duckdb and data/{prefix}_raw.duckdb
+    patterns in the data directory.
+    """
+    # If config.raw_db exists and has a schema matching this source, use it
+    if config.raw_db.exists():
+        try:
+            con = duckdb.connect(str(config.raw_db), read_only=True)
+            schemas = [r[0] for r in con.execute(
+                "SELECT DISTINCT schema_name FROM information_schema.schemata"
+            ).fetchall()]
+            con.close()
+            source_schema = f"raw_{source_name.replace('-', '_')}"
+            if source_schema in schemas:
+                return config.raw_db
+        except duckdb.Error:
+            pass
+
+    # Look for per-source files in the data directory
+    data_dir = config.data_dir
+    if data_dir.exists():
+        for pattern in [
+            f"raw_{source_name.replace('-', '_')}.duckdb",
+            f"*_raw.duckdb",
+        ]:
+            matches = sorted(data_dir.glob(pattern))
+            for match in matches:
+                try:
+                    con = duckdb.connect(str(match), read_only=True)
+                    schemas = [r[0] for r in con.execute(
+                        "SELECT DISTINCT schema_name FROM information_schema.schemata"
+                    ).fetchall()]
+                    con.close()
+                    source_schema = f"raw_{source_name.replace('-', '_')}"
+                    if source_schema in schemas:
+                        return match
+                except duckdb.Error:
+                    continue
+
+    # Fallback: return the expected per-source path (caller will show error)
+    return data_dir / f"raw_{source_name.replace('-', '_')}.duckdb"
 
 
 # ---------------------------------------------------------------------------
-# stats
+# schema (was: stats)
 # ---------------------------------------------------------------------------
 
 
-@app.command()
-def stats() -> None:
-    """Show database file sizes, table counts, and row counts."""
-    header("Database Statistics")
+def schema() -> None:
+    """Show database tables, row counts, and file sizes."""
+    header("Database Schema")
 
     rows: list[tuple[str, str, str]] = []
 
-    for db_path, label in [(config.raw_db, "Raw"), (config.local_db, "Local")]:
+    for db_path, label in [(config.raw_db, "Raw"), (config.local_db, "Warehouse")]:
         size = db_file_size_mb(db_path)
         if size is not None:
             rows.append((f"{label} database", "OK", f"{size:.1f} MB"))
             tables = get_tables(db_path)
-            rows.append((f"  Tables", "", f"{len(tables)}"))
-            for schema, table in tables:
-                count = get_row_count(db_path, schema, table)
+            rows.append(("  Tables", "", f"{len(tables)}"))
+            for s, table in tables:
+                count = get_row_count(db_path, s, table)
                 rows.append((
-                    f"  {schema}.{table}",
+                    f"  {s}.{table}",
                     "",
                     f"{count:,} rows" if count is not None else "empty",
                 ))
         else:
             rows.append((f"{label} database", "WARN", "not found"))
 
-    console.print(status_table(rows, title="Database Statistics"))
+    # Also scan for any other .duckdb files in the data directory
+    data_dir = config.data_dir
+    seen = {config.raw_db.resolve(), config.local_db.resolve()}
+    if data_dir.exists():
+        for db_file in sorted(data_dir.glob("*.duckdb")):
+            if db_file.resolve() in seen:
+                continue
+            seen.add(db_file.resolve())
+            size = db_file_size_mb(db_file)
+            if size is not None:
+                rows.append((db_file.name, "OK", f"{size:.1f} MB"))
+                tables = get_tables(db_file)
+                rows.append(("  Tables", "", f"{len(tables)}"))
+                for s, table in tables:
+                    count = get_row_count(db_file, s, table)
+                    rows.append((
+                        f"  {s}.{table}",
+                        "",
+                        f"{count:,} rows" if count is not None else "empty",
+                    ))
+
+    console.print(status_table(rows, title="Database Schema"))
 
 
 # ---------------------------------------------------------------------------
@@ -55,20 +116,39 @@ def stats() -> None:
 # ---------------------------------------------------------------------------
 
 
-@app.command()
 def query(
     sql: Annotated[str, typer.Argument(help="SQL query to execute.")],
     raw: Annotated[
         bool,
-        typer.Option("--raw", help="Query the raw database instead of local."),
+        typer.Option("--raw", help="Query the raw database instead of the warehouse."),
     ] = False,
+    source: Annotated[
+        str | None,
+        typer.Option("--source", "-s", help="Query a specific source's raw database (e.g. pokeapi)."),
+    ] = None,
+    db: Annotated[
+        Path | None,
+        typer.Option("--db", help="Path to a DuckDB file to query directly."),
+    ] = None,
 ) -> None:
-    """Run a read-only SQL query against the local (or raw) database."""
-    db_path = config.raw_db if raw else config.local_db
-    label = "raw" if raw else "local"
+    """Run a read-only SQL query against the warehouse, raw, or a source database."""
+    if db:
+        db_path = db
+        label = db_path.name
+    elif source:
+        db_path = _resolve_source_db(source)
+        label = f"raw ({source})"
+    elif raw:
+        db_path = config.raw_db
+        label = "raw"
+    else:
+        db_path = config.local_db
+        label = "warehouse"
 
     if not db_path.exists():
-        error(f"The {label} database does not exist at {db_path}")
+        error(f"Database not found at {db_path}")
+        if source:
+            info(f"Run 'tycoon data sources run {source}' to ingest data first.")
         raise typer.Exit(1)
 
     try:
@@ -97,7 +177,6 @@ def query(
 # ---------------------------------------------------------------------------
 
 
-@app.command()
 def clean(
     raw: Annotated[
         bool,
@@ -152,8 +231,6 @@ def clean(
             wal_path.unlink()
 
     if all_:
-        # Clean up any other stale files in the data directory
-        # (only remove files, not subdirectories, to be safe)
         if config.data_dir.exists():
             for item in config.data_dir.iterdir():
                 if item.is_file() and item.suffix in {".duckdb", ".wal"}:

--- a/src/tycoon/commands/doctor.py
+++ b/src/tycoon/commands/doctor.py
@@ -39,7 +39,7 @@ def _check_dbt_project():
     if config.dbt_project_dir.exists() and (config.dbt_project_dir / "dbt_project.yml").exists():
         success("dbt project found.")
     else:
-        error("dbt project not found or is missing `dbt_project.yml`.")
+        warn("dbt project not found. It will be created when you run `tycoon data analyze`.")
 
 
 def _check_rill_project():

--- a/src/tycoon/commands/doctor.py
+++ b/src/tycoon/commands/doctor.py
@@ -9,7 +9,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 from tycoon.config import config
-from tycoon.project import BITool, IngestionTool, OrchestratorTool, WarehouseType
+from tycoon.project import BITool, IngestionTool, OrchestratorTool, TransformationTool, WarehouseType
 from tycoon.utils.console import error, header, info, success, warn
 
 console = Console()
@@ -35,19 +35,35 @@ def _check_tycoon_yml():
 
 
 def _check_dbt_project():
-    """Check if the dbt project exists and is configured correctly."""
+    """Check if the dbt project exists, or report intentional skip."""
+    project = config.project
+    if project and project.stack.transformation == TransformationTool.none:
+        info("dbt: skipped by choice (stack.transformation = none).")
+        return
+
     if config.dbt_project_dir.exists() and (config.dbt_project_dir / "dbt_project.yml").exists():
         success("dbt project found.")
     else:
-        warn("dbt project not found. It will be created when you run `tycoon data analyze`.")
+        warn(
+            "dbt project not found. Run `tycoon init` to scaffold one, "
+            "or point `dbt_project_dir` in tycoon.yml at an existing project."
+        )
 
 
 def _check_rill_project():
-    """Check if the rill project exists."""
+    """Check if the rill project exists, or report intentional skip."""
+    project = config.project
+    if project and project.stack.bi != BITool.rill:
+        if project.stack.bi == BITool.none:
+            info("Rill/BI: skipped by choice (stack.bi = none).")
+        else:
+            info(f"BI is {project.stack.bi.value} (not Rill); skipping Rill checks.")
+        return
+
     if config.rill_dir.exists():
         success("Rill project found.")
     else:
-        warn("Rill project not found. `tycoon data analyze` will create it.")
+        warn("Rill project not found. `tycoon data analyze --rill` will create it.")
 
 
 def _check_stack_config() -> None:
@@ -77,7 +93,9 @@ def _check_stack_config() -> None:
         else:
             success("BigQuery credentials found.")
 
-    if not stack.ingestion_managed:
+    if stack.ingestion == IngestionTool.none:
+        info("Ingestion: skipped by choice (stack.ingestion = none).")
+    elif not stack.ingestion_managed:
         info(f"Ingestion is managed externally by {stack.ingestion.value}. Skipping ingestion checks.")
     elif stack.ingestion == IngestionTool.dlt:
         try:
@@ -94,15 +112,17 @@ def _check_stack_config() -> None:
     elif not stack.bi_managed and stack.bi != BITool.none:
         info(f"BI is managed externally by {stack.bi.value}. Skipping Rill checks.")
 
-    if stack.orchestrator == OrchestratorTool.dagster and stack.orchestrator_managed:
+    if stack.orchestrator == OrchestratorTool.none:
+        info("Orchestrator: skipped by choice (stack.orchestrator = none).")
+    elif stack.orchestrator == OrchestratorTool.dagster and stack.orchestrator_managed:
         if shutil.which("dagster"):
             success("Dagster is installed.")
         else:
             warn("Dagster not found. Run: pip install dagster dagster-webserver")
-    elif not stack.orchestrator_managed and stack.orchestrator != OrchestratorTool.none:
+    elif not stack.orchestrator_managed:
         info(f"Orchestration is managed externally by {stack.orchestrator.value}.")
 
-    if not stack.transformation_managed:
+    if stack.transformation == TransformationTool.dbt and not stack.transformation_managed:
         from pathlib import Path
         dbt_dir = Path(project.dbt_project_dir)
         if not dbt_dir.is_absolute():

--- a/src/tycoon/commands/explore.py
+++ b/src/tycoon/commands/explore.py
@@ -129,33 +129,32 @@ def analyze_cmd(
     # 5. Generate Rill dashboards (opt-in via --rill)
     if rill:
         from tycoon.scaffolding.rill_generator import generate_rill_config
+        from tycoon.scaffolding.templates import scaffold_rill_dir
 
         rill_dir = config.rill_dir
         if not rill_dir.exists():
-            warn(
-                f"Rill project directory not found at {rill_dir}. "
-                "Skipping Rill generation."
+            info(f"Rill project not found; scaffolding at {rill_dir}")
+            scaffold_rill_dir(rill_dir)
+
+        info("Generating Rill sources, metrics views, and dashboards...")
+        try:
+            rill_files = generate_rill_config(
+                raw_db_path=raw_db,
+                warehouse_db_path=config.local_db,
+                schema_name=schema_name,
+                source_name=source_name,
+                output_dir=rill_dir,
             )
-        else:
-            info("Generating Rill sources, metrics views, and dashboards...")
-            try:
-                rill_files = generate_rill_config(
-                    raw_db_path=raw_db,
-                    warehouse_db_path=config.local_db,
-                    schema_name=schema_name,
-                    source_name=source_name,
-                    output_dir=rill_dir,
-                )
-                all_generated.extend(rill_files)
-                if rill_files:
-                    success(f"Generated {len(rill_files)} Rill file(s) in {rill_dir}")
-                    for f in rill_files:
-                        info(f"  {f}")
-                else:
-                    warn("No Rill files generated (no eligible tables found).")
-            except Exception as exc:
-                error(f"Rill generation failed: {exc}")
-                raise typer.Exit(1) from exc
+            all_generated.extend(rill_files)
+            if rill_files:
+                success(f"Generated {len(rill_files)} Rill file(s) in {rill_dir}")
+                for f in rill_files:
+                    info(f"  {f}")
+            else:
+                warn("No Rill files generated (no eligible tables found).")
+        except Exception as exc:
+            error(f"Rill generation failed: {exc}")
+            raise typer.Exit(1) from exc
     else:
         info("Skipping Rill dashboard generation (pass --rill to enable)")
 

--- a/src/tycoon/commands/explore.py
+++ b/src/tycoon/commands/explore.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 from typing import Annotated, Optional
 
+import click
 import typer
 
 from tycoon.config import config
@@ -63,7 +64,7 @@ def analyze_cmd(
             raise typer.Exit(1)
         source_name = typer.prompt(
             "Choose a source to analyze",
-            type=typer.Choice(list(sources.keys())),
+            type=click.Choice(list(sources.keys())),
             show_choices=True,
         )
 

--- a/src/tycoon/commands/init.py
+++ b/src/tycoon/commands/init.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Annotated, Optional
 
 import typer
 
-from tycoon.project import BITool, IngestionTool, OrchestratorTool, StackConfig, WarehouseType
+from tycoon.project import (
+    BITool,
+    IngestionTool,
+    OrchestratorTool,
+    StackConfig,
+    TransformationTool,
+    WarehouseType,
+)
 from tycoon.scaffolding.templates import (
     list_templates,
     scaffold_blank_project,
@@ -32,206 +40,316 @@ def _prompt_choice(prompt: str, options: list[str]) -> int:
         warn(f"Please enter a number between 1 and {len(options)}.")
 
 
-def _detect_existing(target: Path) -> dict:
-    """Scan the working directory for signs of an existing pipeline."""
-    found = {}
+@dataclass
+class DetectedItem:
+    """An auto-detected stack component on disk."""
+
+    path: Path
+    kind: str  # "inline" (inside target) | "sibling" (sibling of target)
+
+
+@dataclass
+class DetectionResults:
+    """Structured output of `_detect_existing`."""
+
+    dbt: list[DetectedItem] = field(default_factory=list)
+    rill: list[DetectedItem] = field(default_factory=list)
+    warehouse: list[DetectedItem] = field(default_factory=list)
+
+    def has_any(self) -> bool:
+        return bool(self.dbt or self.rill or self.warehouse)
+
+
+# Canonical inline subdirs to probe
+_DBT_INLINE_DIRS = ("dbt_project", "dbt", "transformation")
+_RILL_INLINE_DIRS = ("rill", "dashboards")
+
+
+def _detect_existing(target: Path) -> DetectionResults:
+    """Scan the target directory (and its siblings) for existing stack components.
+
+    Looks for:
+      - dbt: ``<target>/<subdir>/dbt_project.yml`` for canonical subdirs, plus
+        ``dbt_project.yml`` in the target root, and any sibling directory of
+        ``target`` that contains a ``dbt_project.yml``.
+      - rill: ``<target>/<subdir>/rill.yaml`` and sibling dirs.
+      - warehouse: any ``<target>/data/*.duckdb`` that doesn't look like a raw
+        ingestion DB (names starting with ``raw_`` or ending in ``_raw``).
+    """
+    results = DetectionResults()
+
+    # dbt — target root (rare but possible)
     if (target / "dbt_project.yml").exists():
-        found["dbt_project"] = str(target / "dbt_project.yml")
-    if (target / "profiles.yml").exists():
-        found["profiles"] = str(target / "profiles.yml")
-    duckdb_files = list(target.glob("**/*.duckdb")) + list((target / "data").glob("*.duckdb") if (target / "data").exists() else [])
-    if duckdb_files:
-        found["duckdb"] = str(duckdb_files[0])
-    return found
+        results.dbt.append(DetectedItem(path=target, kind="inline"))
+
+    # dbt — canonical inline subdirs
+    for sub in _DBT_INLINE_DIRS:
+        candidate = target / sub
+        if (candidate / "dbt_project.yml").exists():
+            results.dbt.append(DetectedItem(path=candidate, kind="inline"))
+
+    # rill — canonical inline subdirs
+    for sub in _RILL_INLINE_DIRS:
+        candidate = target / sub
+        if (candidate / "rill.yaml").exists():
+            results.rill.append(DetectedItem(path=candidate, kind="inline"))
+
+    # warehouse — data/*.duckdb (excluding files that look like raw ingestion DBs)
+    data_dir = target / "data"
+    if data_dir.exists():
+        for db_file in sorted(data_dir.glob("*.duckdb")):
+            name = db_file.stem
+            if name.startswith("raw_") or name.endswith("_raw") or name == "raw":
+                continue
+            results.warehouse.append(DetectedItem(path=db_file, kind="inline"))
+
+    # Siblings — walk one level up, check dirs that look relevant
+    parent = target.parent
+    if parent.exists() and parent != target:
+        for sibling in sorted(parent.iterdir()):
+            if not sibling.is_dir() or sibling == target or sibling.name.startswith("."):
+                continue
+            if (sibling / "dbt_project.yml").exists():
+                results.dbt.append(DetectedItem(path=sibling, kind="sibling"))
+            if (sibling / "rill.yaml").exists():
+                results.rill.append(DetectedItem(path=sibling, kind="sibling"))
+
+    return results
 
 
-def _run_wizard(target: Path, project_name: str) -> tuple[StackConfig, str | None, str | None]:
-    """Run the interactive setup questionnaire.
+@dataclass
+class WizardResult:
+    """Output of the init wizard."""
 
-    Returns (stack, existing_dbt_path, existing_warehouse_path).
+    stack: StackConfig
+    dbt_path: str | None = None  # where dbt project lives (None => skipped)
+    rill_path: str | None = None  # where Rill project lives (None => skipped)
+    warehouse_path: str | None = None  # DuckDB path or cloud conn string
+
+
+def _print_section(title: str) -> None:
+    console.print()
+    console.print(f"[bold cyan]── {title} ──────────────────[/bold cyan]")
+
+
+def _clone_repo(url: str, dest: Path) -> bool:
+    """git clone <url> into <dest>. Returns True on success."""
+    import subprocess
+
+    if dest.exists():
+        warn(f"{dest} already exists; leaving it alone.")
+        return True
+    try:
+        subprocess.run(["git", "clone", url, str(dest)], check=True)
+        success(f"Cloned into {dest}")
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        error(f"git clone failed: {exc}")
+        return False
+
+
+def _prompt_register_project(component: str, default_sibling: Path) -> str | None:
+    """Shared sub-flow for "register existing" — returns absolute path string or None on failure."""
+    raw = typer.prompt(
+        f"Local path or GitHub URL for your {component} project",
+        default="",
+    ).strip()
+    if not raw:
+        warn("No path provided; treating this component as skipped.")
+        return None
+
+    if raw.startswith(("http://", "https://", "git@")):
+        clone_here = typer.confirm(
+            f"Clone into {default_sibling}?",
+            default=True,
+        )
+        dest = default_sibling if clone_here else Path(
+            typer.prompt(f"Where should the {component} project be cloned?", default=str(default_sibling))
+        ).expanduser().resolve()
+        if not _clone_repo(raw, dest):
+            return None
+        return str(dest)
+
+    path = Path(raw).expanduser().resolve()
+    if not path.exists():
+        warn(f"Path {path} does not exist; treating this component as skipped.")
+        return None
+    return str(path)
+
+
+def _prompt_ingestion() -> tuple[IngestionTool, bool]:
+    _print_section("Ingestion")
+    console.print("How do you load data into your warehouse?")
+    choice = _prompt_choice("Choice", [
+        "dlt — tycoon manages it (scaffolds and runs dlt pipelines)",
+        "External (Airbyte / Fivetran / Meltano / custom) — tycoon records only",
+        "Skip — no ingestion configured",
+    ])
+    if choice == 1:
+        return IngestionTool.dlt, True
+    if choice == 2:
+        sub = _prompt_choice("Which external tool?", ["Airbyte", "Fivetran", "Meltano", "Custom"])
+        tool = [IngestionTool.airbyte, IngestionTool.fivetran, IngestionTool.meltano, IngestionTool.none][sub - 1]
+        # "Custom" falls through to IngestionTool.none since we don't have a generic 'external' enum value,
+        # but managed=False still signals tycoon won't run it.
+        return tool, False
+    return IngestionTool.none, False
+
+
+def _prompt_warehouse(project_name: str) -> tuple[WarehouseType, str]:
+    _print_section("Warehouse")
+    console.print("Where should your data live?")
+    choice = _prompt_choice("Choice", [
+        "Local DuckDB at ./data/warehouse.duckdb  [recommended]",
+        "Use an existing DuckDB file (provide path)",
+        "Cloud — MotherDuck / Snowflake / BigQuery",
+    ])
+    if choice == 1:
+        return WarehouseType.duckdb, "data/warehouse.duckdb"
+    if choice == 2:
+        raw = typer.prompt("Path to your DuckDB file", default="data/warehouse.duckdb")
+        return WarehouseType.duckdb, raw
+    # Cloud
+    cloud_sub = _prompt_choice("Cloud warehouse", ["MotherDuck", "Snowflake", "BigQuery"])
+    if cloud_sub == 1:
+        md_name = typer.prompt("MotherDuck database name", default=project_name.replace("-", "_"))
+        return WarehouseType.motherduck, f"md:{md_name}"
+    if cloud_sub == 2:
+        info("Snowflake: tycoon will write your dbt profile; query/schema commands are DuckDB-only for now.")
+        return WarehouseType.snowflake, ""
+    info("BigQuery: tycoon will write your dbt profile; query/schema commands are DuckDB-only for now.")
+    return WarehouseType.bigquery, ""
+
+
+def _prompt_dbt(
+    target: Path,
+    project_name: str,
+    detected: DetectionResults,
+) -> tuple[TransformationTool, bool, str | None]:
+    """Returns (tool, managed, path)."""
+    _print_section("dbt (transformation)")
+    console.print("How should tycoon handle dbt?")
+
+    options: list[str] = []
+    detected_paths: list[Path] = [d.path for d in detected.dbt]
+    for item in detected.dbt:
+        options.append(f"Use detected project at {item.path} ({item.kind})")
+
+    default_new = target.parent / f"{project_name}-dbt"
+    options.append(f"Create new dbt project at {default_new} (sibling repo)")
+    options.append("Register existing project (local path or GitHub URL)")
+    options.append("Skip — `tycoon data transform` becomes a no-op")
+
+    choice = _prompt_choice("Choice", options)
+
+    # Detected
+    if choice <= len(detected_paths):
+        return TransformationTool.dbt, False, str(detected_paths[choice - 1])
+    # Create new (sibling)
+    if choice == len(detected_paths) + 1:
+        return TransformationTool.dbt, True, str(default_new)
+    # Register existing
+    if choice == len(detected_paths) + 2:
+        registered = _prompt_register_project("dbt", default_new)
+        if registered:
+            return TransformationTool.dbt, False, registered
+        return TransformationTool.none, False, None
+    # Skip
+    return TransformationTool.none, False, None
+
+
+def _prompt_rill(
+    target: Path,
+    detected: DetectionResults,
+) -> tuple[BITool, bool, str | None]:
+    """Returns (tool, managed, path)."""
+    _print_section("Rill (BI)")
+    console.print("How should tycoon handle Rill?")
+
+    options: list[str] = []
+    detected_paths: list[Path] = [d.path for d in detected.rill]
+    for item in detected.rill:
+        options.append(f"Use detected project at {item.path} ({item.kind})")
+
+    default_new = target / "rill"
+    options.append(f"Create new inline at {default_new}")
+    options.append("Register existing project (local path)")
+    options.append("Skip — `tycoon data analyze --rill` becomes a no-op")
+
+    choice = _prompt_choice("Choice", options)
+
+    # Detected
+    if choice <= len(detected_paths):
+        return BITool.rill, False, str(detected_paths[choice - 1])
+    # Create new (inline)
+    if choice == len(detected_paths) + 1:
+        return BITool.rill, True, str(default_new)
+    # Register
+    if choice == len(detected_paths) + 2:
+        registered = _prompt_register_project("Rill", default_new)
+        if registered:
+            return BITool.rill, False, registered
+        return BITool.none, False, None
+    # Skip
+    return BITool.none, False, None
+
+
+def _prompt_orchestrator() -> tuple[OrchestratorTool, bool]:
+    _print_section("Orchestrator")
+    console.print("How should tycoon handle scheduling?")
+    choice = _prompt_choice("Choice", [
+        "Dagster — tycoon manages it (runs `dagster dev`, auto-generates assets)",
+        "External (Airflow / Prefect / Dagster Cloud / other) — tycoon records only",
+        "Skip — I'll run pipelines manually via tycoon CLI",
+    ])
+    if choice == 1:
+        return OrchestratorTool.dagster, True
+    if choice == 2:
+        sub = _prompt_choice("Which external orchestrator?", ["Airflow", "Prefect", "Other"])
+        tool = [OrchestratorTool.airflow, OrchestratorTool.prefect, OrchestratorTool.other][sub - 1]
+        return tool, False
+    return OrchestratorTool.none, False
+
+
+def _run_wizard(target: Path, project_name: str) -> WizardResult:
+    """Run the interactive setup questionnaire, per-component.
+
+    Order follows the data flow: ingestion → warehouse → dbt → rill → orchestrator.
     """
     detected = _detect_existing(target)
-    if detected:
-        info("Detected existing files:")
-        for key, path in detected.items():
-            console.print(f"  [dim]{key}:[/dim] {path}")
+    if detected.has_any():
+        info("Detected existing components:")
+        for item in detected.dbt:
+            console.print(f"  [dim]dbt   [{item.kind}]:[/dim] {item.path}")
+        for item in detected.rill:
+            console.print(f"  [dim]rill  [{item.kind}]:[/dim] {item.path}")
+        for item in detected.warehouse:
+            console.print(f"  [dim]warehouse [{item.kind}]:[/dim] {item.path}")
         console.print()
 
-    has_pipeline = typer.confirm("Do you already have a data pipeline?", default=False)
+    ingestion, ingestion_managed = _prompt_ingestion()
+    warehouse, warehouse_path = _prompt_warehouse(project_name)
+    transformation, transformation_managed, dbt_path = _prompt_dbt(target, project_name, detected)
+    bi, bi_managed, rill_path = _prompt_rill(target, detected)
+    orchestrator, orchestrator_managed = _prompt_orchestrator()
 
-    existing_dbt_path: str | None = None
-    existing_warehouse_path: str | None = None
-
-    if has_pipeline:
-        # --- Ingestion ---
-        console.print("\nWhat do you use for ingestion?")
-        ingestion_choice = _prompt_choice("Choice", [
-            "dlt (tycoon will manage it)",
-            "Airbyte / Fivetran / Meltano (external — tycoon won't run it)",
-            "None / I just have data I want to query",
-        ])
-        if ingestion_choice == 1:
-            ingestion = IngestionTool.dlt
-            ingestion_managed = True
-        elif ingestion_choice == 2:
-            console.print("\nWhich external tool?")
-            ext_choice = _prompt_choice("Choice", ["Airbyte", "Fivetran", "Meltano"])
-            ingestion = [IngestionTool.airbyte, IngestionTool.fivetran, IngestionTool.meltano][ext_choice - 1]
-            ingestion_managed = False
-        else:
-            ingestion = IngestionTool.none
-            ingestion_managed = False
-
-        # --- Warehouse ---
-        console.print("\nWhere is your data?")
-        wh_choice = _prompt_choice("Choice", [
-            "Local DuckDB file",
-            "MotherDuck (cloud DuckDB)",
-            "Snowflake",
-            "BigQuery",
-            "Other",
-        ])
-        wh_map = [
-            WarehouseType.duckdb,
-            WarehouseType.motherduck,
-            WarehouseType.snowflake,
-            WarehouseType.bigquery,
-            WarehouseType.other,
-        ]
-        warehouse = wh_map[wh_choice - 1]
-
-        if warehouse == WarehouseType.duckdb:
-            default_path = detected.get("duckdb", "data/warehouse.duckdb")
-            existing_warehouse_path = typer.prompt("Path to your DuckDB file", default=default_path)
-        elif warehouse == WarehouseType.motherduck:
-            md_name = typer.prompt("MotherDuck database name", default=project_name.replace("-", "_"))
-            existing_warehouse_path = f"md:{md_name}"
-        elif warehouse in (WarehouseType.snowflake, WarehouseType.bigquery, WarehouseType.redshift):
-            info(f"Native {warehouse.value.title()} querying via `tycoon data db` is coming in 0.8.")
-            info("tycoon will record your warehouse type and manage dbt against it using your profiles.yml.")
-
-        # --- dbt ---
-        console.print()
-        has_dbt = typer.confirm("Do you have an existing dbt project?", default=bool(detected.get("dbt_project")))
-        if has_dbt:
-            default_dbt = detected.get("dbt_project", "")
-            if default_dbt.endswith("dbt_project.yml"):
-                default_dbt = str(Path(default_dbt).parent)
-            existing_dbt_path = typer.prompt("Path to your dbt project directory", default=default_dbt or str(target.parent / f"{project_name}-dbt"))
-            transformation_managed = False
-        else:
-            create_dbt = typer.confirm("Would you like tycoon to scaffold a dbt project?", default=True)
-            if create_dbt:
-                default_new_dbt = str(target.parent / f"{project_name}-dbt")
-                existing_dbt_path = typer.prompt("Where should the dbt project live?", default=default_new_dbt)
-                transformation_managed = True
-            else:
-                existing_dbt_path = None
-                transformation_managed = False
-
-        # --- BI Tool ---
-        console.print()
-        console.print("Do you have a BI / dashboard tool?")
-        bi_choice = _prompt_choice("Choice", [
-            "Rill (tycoon will manage it)",
-            "Metabase / Looker / Tableau / other (external)",
-            "None yet",
-        ])
-        if bi_choice == 1:
-            bi = BITool.rill
-            bi_managed = True
-        elif bi_choice == 2:
-            console.print()
-            console.print("Which BI tool?")
-            bi_ext_choice = _prompt_choice("Choice", ["Metabase", "Looker", "Tableau", "Other"])
-            bi = [BITool.metabase, BITool.looker, BITool.tableau, BITool.other][bi_ext_choice - 1]
-            bi_managed = False
-        else:
-            bi = BITool.none
-            bi_managed = False
-
-        # --- Orchestrator ---
-        console.print()
-        console.print("Do you have an orchestrator?")
-        orch_choice = _prompt_choice("Choice", [
-            "Dagster (tycoon will manage it)",
-            "Airflow / Prefect / other (external)",
-            "None / I'll run pipelines manually",
-        ])
-        if orch_choice == 1:
-            orchestrator = OrchestratorTool.dagster
-            orchestrator_managed = True
-        elif orch_choice == 2:
-            console.print()
-            console.print("Which orchestrator?")
-            orch_ext_choice = _prompt_choice("Choice", ["Airflow", "Prefect", "Other"])
-            orchestrator = [OrchestratorTool.airflow, OrchestratorTool.prefect, OrchestratorTool.other][orch_ext_choice - 1]
-            orchestrator_managed = False
-        else:
-            orchestrator = OrchestratorTool.none
-            orchestrator_managed = False
-
-        stack = StackConfig(
-            ingestion=ingestion,
-            ingestion_managed=ingestion_managed,
-            warehouse=warehouse,
-            transformation_managed=transformation_managed,
-            bi=bi,
-            bi_managed=bi_managed,
-            orchestrator=orchestrator,
-            orchestrator_managed=orchestrator_managed,
-        )
-
-    else:
-        # Greenfield — pick warehouse
-        console.print("\nWhere would you like to store your data?")
-        wh_choice = _prompt_choice("Choice", [
-            "Local DuckDB (zero-config)",
-            "MotherDuck (cloud DuckDB — requires MOTHERDUCK_TOKEN)",
-        ])
-        if wh_choice == 2:
-            md_name = typer.prompt("MotherDuck database name", default=project_name.replace("-", "_"))
-            existing_warehouse_path = f"md:{md_name}"
-            warehouse = WarehouseType.motherduck
-        else:
-            warehouse = WarehouseType.duckdb
-
-        # dbt location
-        console.print()
-        default_new_dbt = str(target.parent / f"{project_name}-dbt")
-        existing_dbt_path = typer.prompt("Where should the dbt project live?", default=default_new_dbt)
-
-        # BI tool
-        console.print("\nWhich BI / dashboard tool would you like to use?")
-        bi_choice = _prompt_choice("Choice", [
-            "Rill (tycoon will manage it — recommended)",
-            "I'll connect my own BI tool",
-            "None / skip",
-        ])
-        bi = BITool.rill if bi_choice == 1 else BITool.none
-        bi_managed = bi_choice == 1
-
-        # Orchestrator
-        console.print("\nHow would you like to run your pipelines?")
-        orch_choice = _prompt_choice("Choice", [
-            "Dagster (tycoon will manage it — recommended)",
-            "Manually via tycoon CLI commands",
-        ])
-        orchestrator = OrchestratorTool.dagster if orch_choice == 1 else OrchestratorTool.none
-        orchestrator_managed = orch_choice == 1
-
-        stack = StackConfig(
-            ingestion=IngestionTool.dlt,
-            ingestion_managed=True,
-            warehouse=warehouse,
-            transformation_managed=True,
-            bi=bi,
-            bi_managed=bi_managed,
-            orchestrator=orchestrator,
-            orchestrator_managed=orchestrator_managed,
-        )
-
-    return stack, existing_dbt_path, existing_warehouse_path
+    stack = StackConfig(
+        ingestion=ingestion,
+        ingestion_managed=ingestion_managed,
+        warehouse=warehouse,
+        transformation=transformation,
+        transformation_managed=transformation_managed,
+        bi=bi,
+        bi_managed=bi_managed,
+        orchestrator=orchestrator,
+        orchestrator_managed=orchestrator_managed,
+    )
+    return WizardResult(
+        stack=stack,
+        dbt_path=dbt_path,
+        rill_path=rill_path,
+        warehouse_path=warehouse_path,
+    )
 
 
 def _mode_next_steps(stack: StackConfig, existing_dbt_path: str | None) -> None:
@@ -319,15 +437,16 @@ def init_cmd(
             ("tycoon ask init", "set up the AI analytics agent"),
         )
     else:
-        stack, existing_dbt_path, existing_warehouse_path = _run_wizard(target, project_name)
+        result = _run_wizard(target, project_name)
         console.print()
         scaffold_blank_project(
             target,
             project_name,
-            stack=stack,
-            existing_dbt_path=existing_dbt_path,
-            existing_warehouse_path=existing_warehouse_path,
+            stack=result.stack,
+            existing_dbt_path=result.dbt_path,
+            existing_warehouse_path=result.warehouse_path,
+            existing_rill_path=result.rill_path,
         )
         console.print()
         success(f"Project '{project_name}' initialized successfully!")
-        _mode_next_steps(stack, existing_dbt_path)
+        _mode_next_steps(result.stack, result.dbt_path)

--- a/src/tycoon/commands/init.py
+++ b/src/tycoon/commands/init.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Annotated, Optional
 
 import typer
+import yaml
 
 from tycoon.project import (
     BITool,
@@ -294,6 +295,85 @@ def _prompt_rill(
     return BITool.none, False, None
 
 
+def _extract_dbt_duckdb_path(dbt_project_dir: Path) -> str | None:
+    """Extract the DuckDB path from a dbt project's active profile.
+
+    Returns an absolute path string, or None if:
+    - ``dbt_project.yml`` missing or unreadable
+    - no ``profiles.yml`` in the project dir or ``~/.dbt/``
+    - the target's ``type`` is not ``duckdb``
+    """
+    try:
+        project_yml = yaml.safe_load((dbt_project_dir / "dbt_project.yml").read_text())
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(project_yml, dict):
+        return None
+    profile_name = project_yml.get("profile")
+    if not profile_name:
+        return None
+
+    for candidate in (
+        dbt_project_dir / "profiles.yml",
+        Path.home() / ".dbt" / "profiles.yml",
+    ):
+        if not candidate.exists():
+            continue
+        try:
+            profiles = yaml.safe_load(candidate.read_text())
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(profiles, dict):
+            continue
+        profile = profiles.get(profile_name)
+        if not isinstance(profile, dict):
+            continue
+        target_name = profile.get("target", "dev")
+        target = profile.get("outputs", {}).get(target_name, {})
+        if not isinstance(target, dict) or target.get("type") != "duckdb":
+            return None
+        path = target.get("path")
+        if not path:
+            return None
+        abs_path = Path(path)
+        if not abs_path.is_absolute():
+            abs_path = (dbt_project_dir / abs_path).resolve()
+        return str(abs_path)
+    return None
+
+
+def _maybe_align_warehouse(wizard_warehouse_path: str, dbt_project_dir: Path) -> str:
+    """Warn if the dbt project targets a different DuckDB than the wizard's
+    warehouse choice. Prompt to adopt the dbt path."""
+    dbt_path = _extract_dbt_duckdb_path(dbt_project_dir)
+    if not dbt_path:
+        return wizard_warehouse_path
+
+    user_abs = Path(wizard_warehouse_path).expanduser()
+    if not user_abs.is_absolute():
+        user_abs = (Path.cwd() / user_abs).resolve()
+    else:
+        user_abs = user_abs.resolve()
+
+    if str(user_abs) == dbt_path:
+        return wizard_warehouse_path
+
+    console.print()
+    warn(
+        f"Your dbt project targets [bold]{dbt_path}[/bold], "
+        f"but you chose [bold]{wizard_warehouse_path}[/bold] for the warehouse."
+    )
+    info("If these diverge, dbt writes to one file and `tycoon data query` reads from another.")
+    adopt = typer.confirm(
+        f"Use the dbt project's path ({dbt_path}) as tycoon's warehouse?",
+        default=True,
+    )
+    if adopt:
+        success(f"Adopted {dbt_path} as the warehouse.")
+        return dbt_path
+    return wizard_warehouse_path
+
+
 def _prompt_orchestrator() -> tuple[OrchestratorTool, bool]:
     _print_section("Orchestrator")
     console.print("How should tycoon handle scheduling?")
@@ -330,6 +410,17 @@ def _run_wizard(target: Path, project_name: str) -> WizardResult:
     ingestion, ingestion_managed = _prompt_ingestion()
     warehouse, warehouse_path = _prompt_warehouse(project_name)
     transformation, transformation_managed, dbt_path = _prompt_dbt(target, project_name, detected)
+
+    # Alignment check: if dbt project wasn't just scaffolded by us, see if it
+    # targets a different DuckDB than the user chose for the warehouse.
+    if (
+        transformation == TransformationTool.dbt
+        and not transformation_managed
+        and dbt_path
+        and warehouse == WarehouseType.duckdb
+    ):
+        warehouse_path = _maybe_align_warehouse(warehouse_path, Path(dbt_path))
+
     bi, bi_managed, rill_path = _prompt_rill(target, detected)
     orchestrator, orchestrator_managed = _prompt_orchestrator()
 

--- a/src/tycoon/commands/register.py
+++ b/src/tycoon/commands/register.py
@@ -1,0 +1,187 @@
+"""tycoon register — attach an existing dbt or Rill project to tycoon.yml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+import yaml
+
+from tycoon.commands.init import (
+    _clone_repo,
+    _extract_dbt_duckdb_path,
+)
+from tycoon.config import config
+from tycoon.project import (
+    BITool,
+    PROJECT_FILENAME,
+    TransformationTool,
+    WarehouseType,
+)
+from tycoon.utils.console import console, error, header, info, success, warn
+
+
+app = typer.Typer(
+    help="Attach an existing dbt or Rill project to the current tycoon.yml.",
+    no_args_is_help=True,
+)
+
+
+def _resolve_path_or_url(source: str, default_clone_dest: Path) -> Path | None:
+    """Accept a local path or a git URL. Clone if URL. Return resolved absolute path."""
+    if source.startswith(("http://", "https://", "git@")):
+        clone_here = typer.confirm(
+            f"Clone into {default_clone_dest}?",
+            default=True,
+        )
+        dest = default_clone_dest
+        if not clone_here:
+            dest = Path(
+                typer.prompt("Where should the project be cloned?", default=str(default_clone_dest))
+            ).expanduser().resolve()
+        if not _clone_repo(source, dest):
+            return None
+        return dest
+
+    path = Path(source).expanduser().resolve()
+    if not path.exists():
+        error(f"Path does not exist: {path}")
+        return None
+    return path
+
+
+def _require_tycoon_yml() -> Path:
+    """Resolve the tycoon.yml path, or bail if no project."""
+    if not config.has_project_file:
+        error(
+            "No tycoon.yml found in the current project. "
+            "Run `tycoon init` first, or cd into an existing tycoon project."
+        )
+        raise typer.Exit(1)
+    return config.root / PROJECT_FILENAME
+
+
+def _load_raw_tycoon_yml(path: Path) -> dict:
+    """Load tycoon.yml as a raw dict (preserving unknown keys on write)."""
+    raw = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(raw, dict):
+        error(f"tycoon.yml is not a mapping: {path}")
+        raise typer.Exit(1)
+    return raw
+
+
+def _write_raw_tycoon_yml(path: Path, data: dict) -> None:
+    path.write_text(yaml.dump(data, default_flow_style=False, sort_keys=False))
+
+
+@app.command(name="dbt")
+def register_dbt(
+    source: Annotated[
+        str,
+        typer.Argument(help="Local path or GitHub URL of the dbt project to register."),
+    ],
+) -> None:
+    """Attach an existing dbt project to the current tycoon.yml."""
+    header("Register dbt project")
+
+    yml_path = _require_tycoon_yml()
+    raw = _load_raw_tycoon_yml(yml_path)
+
+    existing_dbt = raw.get("dbt_project_dir")
+    if existing_dbt:
+        warn(f"tycoon.yml already has dbt_project_dir = {existing_dbt!r}.")
+        if not typer.confirm("Overwrite it?", default=False):
+            info("Aborted; no changes made.")
+            raise typer.Exit(0)
+
+    default_clone = config.root.parent / f"{raw.get('name', config.root.name)}-dbt"
+    resolved = _resolve_path_or_url(source, default_clone)
+    if resolved is None:
+        raise typer.Exit(1)
+    if not (resolved / "dbt_project.yml").exists():
+        error(f"{resolved} does not contain a dbt_project.yml")
+        raise typer.Exit(1)
+
+    # Write path relative to tycoon.yml when possible, otherwise absolute
+    try:
+        import os
+        rel = os.path.relpath(resolved, config.root)
+        raw["dbt_project_dir"] = rel
+    except ValueError:
+        raw["dbt_project_dir"] = str(resolved)
+
+    # Update stack to reflect "external dbt"
+    stack = raw.setdefault("stack", {})
+    stack["transformation"] = TransformationTool.dbt.value
+    stack["transformation_managed"] = False
+
+    # Warehouse alignment offer
+    dbt_warehouse = _extract_dbt_duckdb_path(resolved)
+    if dbt_warehouse:
+        current_warehouse = raw.get("database", {}).get("warehouse", "")
+        current_abs = (
+            Path(current_warehouse).expanduser()
+            if current_warehouse.startswith(("/", "~"))
+            else config.root / current_warehouse
+        )
+        current_abs = current_abs.resolve() if current_abs.exists() or current_abs.is_absolute() else (config.root / current_warehouse).resolve()
+        if str(current_abs) != dbt_warehouse:
+            console.print()
+            warn(
+                f"Your dbt project targets {dbt_warehouse}, "
+                f"but tycoon.yml has warehouse = {current_warehouse!r}."
+            )
+            if typer.confirm(f"Update warehouse to {dbt_warehouse}?", default=True):
+                raw.setdefault("database", {})["warehouse"] = dbt_warehouse
+                if raw["database"].get("raw", "") == current_warehouse:
+                    raw["database"]["raw"] = dbt_warehouse
+                stack["warehouse"] = WarehouseType.duckdb.value
+
+    _write_raw_tycoon_yml(yml_path, raw)
+    success(f"Registered dbt project at {resolved}")
+    info(f"Updated {yml_path.name}.")
+
+
+@app.command(name="rill")
+def register_rill(
+    source: Annotated[
+        str,
+        typer.Argument(help="Local path or GitHub URL of the Rill project to register."),
+    ],
+) -> None:
+    """Attach an existing Rill project to the current tycoon.yml."""
+    header("Register Rill project")
+
+    yml_path = _require_tycoon_yml()
+    raw = _load_raw_tycoon_yml(yml_path)
+
+    existing_rill = raw.get("rill_dir")
+    if existing_rill:
+        warn(f"tycoon.yml already has rill_dir = {existing_rill!r}.")
+        if not typer.confirm("Overwrite it?", default=False):
+            info("Aborted; no changes made.")
+            raise typer.Exit(0)
+
+    default_clone = config.root.parent / f"{raw.get('name', config.root.name)}-rill"
+    resolved = _resolve_path_or_url(source, default_clone)
+    if resolved is None:
+        raise typer.Exit(1)
+    if not (resolved / "rill.yaml").exists():
+        error(f"{resolved} does not contain a rill.yaml")
+        raise typer.Exit(1)
+
+    import os
+    try:
+        rel = os.path.relpath(resolved, config.root)
+        raw["rill_dir"] = rel
+    except ValueError:
+        raw["rill_dir"] = str(resolved)
+
+    stack = raw.setdefault("stack", {})
+    stack["bi"] = BITool.rill.value
+    stack["bi_managed"] = False
+
+    _write_raw_tycoon_yml(yml_path, raw)
+    success(f"Registered Rill project at {resolved}")
+    info(f"Updated {yml_path.name}.")

--- a/src/tycoon/commands/sources.py
+++ b/src/tycoon/commands/sources.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Optional
 
+import click
 import typer
 from rich.table import Table
 
@@ -424,7 +425,7 @@ def run_source(
             raise typer.Exit(1)
         source_name = typer.prompt(
             "Choose a source to ingest",
-            type=typer.Choice(list(sources.keys())),
+            type=click.Choice(list(sources.keys())),
             show_choices=True,
         )
 

--- a/src/tycoon/commands/transform.py
+++ b/src/tycoon/commands/transform.py
@@ -44,11 +44,18 @@ def _run_dbt(
     full_refresh: bool,
     extra: list[str] | None = None,
 ) -> int:
-    """Invoke dbt as a subprocess from the configured dbt project directory."""
+    """Invoke dbt as a subprocess from the configured dbt project directory.
+
+    Only passes ``--profiles-dir`` when the project has a co-located
+    ``profiles.yml``; otherwise dbt falls back to ``~/.dbt/profiles.yml``,
+    which is typical for externally-registered projects.
+    """
     dbt = _dbt_executable()
     project_dir = config.dbt_project_dir
 
-    cmd = [dbt, dbt_cmd, "--target", target, "--profiles-dir", str(project_dir)]
+    cmd = [dbt, dbt_cmd, "--target", target]
+    if (project_dir / "profiles.yml").exists():
+        cmd += ["--profiles-dir", str(project_dir)]
     if select:
         cmd += ["--select", select]
     if full_refresh:
@@ -158,7 +165,9 @@ def docs(
 
     dbt = _dbt_executable()
     project_dir = config.dbt_project_dir
-    cmd = [dbt, "docs", "serve", "--port", str(port), "--profiles-dir", str(project_dir)]
+    cmd = [dbt, "docs", "serve", "--port", str(port)]
+    if (project_dir / "profiles.yml").exists():
+        cmd += ["--profiles-dir", str(project_dir)]
 
     console.print(f"[dim]Running: {' '.join(cmd)}[/dim]")
     console.print(f"[bold green]dbt docs available at http://localhost:{port}[/bold green]")

--- a/src/tycoon/project.py
+++ b/src/tycoon/project.py
@@ -46,10 +46,16 @@ class OrchestratorTool(str, Enum):
     none = "none"
 
 
+class TransformationTool(str, Enum):
+    dbt = "dbt"
+    none = "none"
+
+
 class StackConfig(BaseModel):
     ingestion: IngestionTool = IngestionTool.dlt
     ingestion_managed: bool = True
     warehouse: WarehouseType = WarehouseType.duckdb
+    transformation: TransformationTool = TransformationTool.dbt
     transformation_managed: bool = True
     bi: BITool = BITool.rill
     bi_managed: bool = True

--- a/src/tycoon/scaffolding/templates.py
+++ b/src/tycoon/scaffolding/templates.py
@@ -103,19 +103,25 @@ def scaffold_blank_project(
     stack: StackConfig | None = None,
     existing_dbt_path: str | None = None,
     existing_warehouse_path: str | None = None,
+    existing_rill_path: str | None = None,
 ) -> None:
-    """Create a minimal tycoon project with an empty ``tycoon.yml``.
+    """Create a minimal tycoon project with a ``tycoon.yml`` and supporting dirs.
 
-    Creates:
-    - ``tycoon.yml`` with the given project name and database paths
-    - ``data/`` directory
-    - ``dbt_project/`` with minimal ``dbt_project.yml`` and ``profiles.yml``
-      (skipped when ``existing_dbt_path`` is provided)
-    - ``.gitignore``
+    Behavior flexes by ``stack`` settings:
+    - ``stack.transformation == none`` → don't scaffold or record dbt at all.
+    - ``stack.transformation == dbt`` + ``transformation_managed`` → scaffold
+      dbt project at ``existing_dbt_path`` (or target/dbt_project).
+    - ``stack.transformation == dbt`` + not managed → just record the path.
+    - ``stack.bi == rill`` + ``bi_managed`` → scaffold Rill dir.
+    - ``stack.bi == rill`` + not managed → record the path only.
+    - ``stack.bi == none`` → don't scaffold or record Rill.
     """
-    from tycoon.project import WarehouseType
+    from tycoon.project import BITool, TransformationTool, WarehouseType
 
-    # Resolve database paths based on warehouse type
+    transformation = stack.transformation if stack else TransformationTool.dbt
+    bi = stack.bi if stack else BITool.rill
+
+    # ---- Warehouse resolution ----
     if stack and stack.warehouse == WarehouseType.motherduck:
         safe_name = name.replace("-", "_")
         raw_db_path = f"md:{safe_name}_raw"
@@ -127,14 +133,7 @@ def scaffold_blank_project(
         raw_db_path = "data/raw.duckdb"
         warehouse_db_path = "data/warehouse.duckdb"
 
-    # Resolve dbt path — may be external, store relative to tycoon.yml
-    if existing_dbt_path:
-        dbt_abs = Path(existing_dbt_path).resolve()
-        dbt_project_dir = _project_relative(target, dbt_abs)
-    else:
-        dbt_project_dir = "dbt_project"
-
-    # tycoon.yml
+    # ---- tycoon.yml data ----
     project_data: dict = {
         "name": name,
         "version": "0.1.0",
@@ -142,92 +141,136 @@ def scaffold_blank_project(
             "raw": raw_db_path,
             "warehouse": warehouse_db_path,
         },
-        "dbt_project_dir": dbt_project_dir,
-        "rill_dir": "rill",
         "sources": {},
     }
+
+    # dbt path — only record if dbt is active
+    if transformation == TransformationTool.dbt and existing_dbt_path:
+        dbt_abs = Path(existing_dbt_path).resolve()
+        project_data["dbt_project_dir"] = _project_relative(target, dbt_abs)
+    elif transformation == TransformationTool.dbt:
+        project_data["dbt_project_dir"] = "dbt_project"
+
+    # rill path — only record if Rill is active
+    if bi == BITool.rill and existing_rill_path:
+        rill_abs = Path(existing_rill_path).resolve()
+        project_data["rill_dir"] = _project_relative(target, rill_abs)
+    elif bi == BITool.rill:
+        project_data["rill_dir"] = "rill"
+
     if stack:
         project_data["stack"] = {
             "ingestion": stack.ingestion.value,
             "ingestion_managed": stack.ingestion_managed,
             "warehouse": stack.warehouse.value,
+            "transformation": stack.transformation.value,
             "transformation_managed": stack.transformation_managed,
+            "bi": stack.bi.value,
+            "bi_managed": stack.bi_managed,
+            "orchestrator": stack.orchestrator.value,
+            "orchestrator_managed": stack.orchestrator_managed,
         }
 
     yml_path = target / "tycoon.yml"
     yml_path.write_text(yaml.dump(project_data, default_flow_style=False, sort_keys=False))
     success(f"Created {yml_path.relative_to(target)}")
 
-    # data/
+    # ---- data/ ----
     (target / "data").mkdir(parents=True, exist_ok=True)
     info("Created data/")
 
-    # dbt_project/ — scaffold at resolved external path, or skip if existing
-    dbt_abs = Path(existing_dbt_path).resolve() if existing_dbt_path else None
-    dbt_already_exists = dbt_abs and dbt_abs.exists() and (dbt_abs / "dbt_project.yml").exists()
+    # ---- dbt scaffold (if active, managed, and project doesn't already exist) ----
+    if transformation == TransformationTool.dbt:
+        dbt_abs = Path(existing_dbt_path).resolve() if existing_dbt_path else (target / "dbt_project")
+        dbt_already_exists = dbt_abs.exists() and (dbt_abs / "dbt_project.yml").exists()
 
-    if dbt_already_exists:
-        info(f"Using existing dbt project at {existing_dbt_path}")
-    elif not stack or stack.transformation_managed:
-        dbt_dir = dbt_abs if dbt_abs else (target / "dbt_project")
-        dbt_dir.mkdir(parents=True, exist_ok=True)
+        if dbt_already_exists:
+            info(f"Using existing dbt project at {dbt_abs}")
+        elif stack is None or stack.transformation_managed:
+            _scaffold_dbt_project(
+                dbt_dir=dbt_abs,
+                name=name,
+                warehouse=stack.warehouse if stack else WarehouseType.duckdb,
+                warehouse_db_path=warehouse_db_path,
+                raw_db_path=raw_db_path,
+                target=target,
+            )
 
-        profile_name = name.replace("-", "_")
+    # ---- Rill scaffold (if active and managed) ----
+    if bi == BITool.rill:
+        rill_abs = Path(existing_rill_path).resolve() if existing_rill_path else (target / "rill")
+        rill_already_exists = rill_abs.exists() and (rill_abs / "rill.yaml").exists()
+        if rill_already_exists:
+            info(f"Using existing Rill project at {rill_abs}")
+        elif stack is None or stack.bi_managed:
+            scaffold_rill_dir(rill_abs)
 
-        dbt_project_yml = {
-            "name": profile_name,
-            "version": "1.0.0",
-            "config-version": 2,
-            "profile": profile_name,
-        }
-        (dbt_dir / "dbt_project.yml").write_text(
-            yaml.dump(dbt_project_yml, default_flow_style=False, sort_keys=False)
-        )
-
-        # profiles.yml: warehouse DB is the dbt target; raw DB is attached read-only.
-        # Paths are relative from dbt_dir, which may be a sibling of the tycoon root.
-        if stack and stack.warehouse == WarehouseType.motherduck:
-            profiles_data = {
-                profile_name: {
-                    "target": "dev",
-                    "outputs": {
-                        "dev": {
-                            "type": "duckdb",
-                            "path": warehouse_db_path,
-                            "attach": [{"path": raw_db_path, "alias": "raw", "read_only": True}],
-                        }
-                    },
-                }
-            }
-        else:
-            warehouse_abs = (target / warehouse_db_path).resolve()
-            raw_abs = (target / raw_db_path).resolve()
-            warehouse_rel = os.path.relpath(warehouse_abs, start=dbt_dir)
-            raw_rel = os.path.relpath(raw_abs, start=dbt_dir)
-            profiles_data = {
-                profile_name: {
-                    "target": "dev",
-                    "outputs": {
-                        "dev": {
-                            "type": "duckdb",
-                            "path": warehouse_rel,
-                            "attach": [{"path": raw_rel, "alias": "raw", "read_only": True}],
-                        }
-                    },
-                }
-            }
-
-        (dbt_dir / "profiles.yml").write_text(
-            yaml.dump(profiles_data, default_flow_style=False, sort_keys=False)
-        )
-        info(f"Created dbt project at {dbt_dir} with dbt_project.yml and profiles.yml")
-
-    # rill/
-    if not stack or stack.bi_managed:
-        _scaffold_rill_dir(target)
-
-    # .gitignore
+    # ---- .gitignore ----
     _write_gitignore(target)
+
+
+def _scaffold_dbt_project(
+    dbt_dir: Path,
+    name: str,
+    warehouse,
+    warehouse_db_path: str,
+    raw_db_path: str,
+    target: Path,
+) -> None:
+    """Write dbt_project.yml + profiles.yml into ``dbt_dir``."""
+    from tycoon.project import WarehouseType
+
+    dbt_dir.mkdir(parents=True, exist_ok=True)
+    profile_name = name.replace("-", "_")
+
+    (dbt_dir / "dbt_project.yml").write_text(
+        yaml.dump(
+            {
+                "name": profile_name,
+                "version": "1.0.0",
+                "config-version": 2,
+                "profile": profile_name,
+            },
+            default_flow_style=False,
+            sort_keys=False,
+        )
+    )
+
+    if warehouse == WarehouseType.motherduck:
+        profiles_data = {
+            profile_name: {
+                "target": "dev",
+                "outputs": {
+                    "dev": {
+                        "type": "duckdb",
+                        "path": warehouse_db_path,
+                        "attach": [{"path": raw_db_path, "alias": "raw", "read_only": True}],
+                    }
+                },
+            }
+        }
+    else:
+        warehouse_abs = (target / warehouse_db_path).resolve()
+        raw_abs = (target / raw_db_path).resolve()
+        warehouse_rel = os.path.relpath(warehouse_abs, start=dbt_dir)
+        raw_rel = os.path.relpath(raw_abs, start=dbt_dir)
+        profiles_data = {
+            profile_name: {
+                "target": "dev",
+                "outputs": {
+                    "dev": {
+                        "type": "duckdb",
+                        "path": warehouse_rel,
+                        "attach": [{"path": raw_rel, "alias": "raw", "read_only": True}],
+                    }
+                },
+            }
+        }
+
+    (dbt_dir / "profiles.yml").write_text(
+        yaml.dump(profiles_data, default_flow_style=False, sort_keys=False)
+    )
+    info(f"Created dbt project at {dbt_dir} with dbt_project.yml and profiles.yml")
 
 
 # ---------------------------------------------------------------------------
@@ -279,7 +322,7 @@ def scaffold_from_template(target: Path, template_name: str) -> None:
 
     # rill/ — scaffold if the template didn't include one
     if not (target / "rill").exists():
-        _scaffold_rill_dir(target)
+        scaffold_rill_dir(target / "rill")
 
     # .gitignore
     _write_gitignore(target)
@@ -300,11 +343,10 @@ def _write_gitignore(target: Path) -> None:
         info("Created .gitignore")
 
 
-def _scaffold_rill_dir(target: Path) -> None:
-    """Create a minimal rill/ project directory with rill.yaml."""
-    rill_dir = target / "rill"
-    rill_dir.mkdir(exist_ok=True)
+def scaffold_rill_dir(rill_dir: Path) -> None:
+    """Create a minimal Rill project directory with rill.yaml."""
+    rill_dir.mkdir(parents=True, exist_ok=True)
     rill_yaml = rill_dir / "rill.yaml"
     if not rill_yaml.exists():
         rill_yaml.write_text(_RILL_YAML_CONTENT)
-        info("Created rill/ with rill.yaml")
+        info(f"Created {rill_dir}/ with rill.yaml")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ class TestCLIHelp:
         result = cli_runner.invoke(app, ["data", "--help"])
         assert result.exit_code == 0
         output = result.stdout
-        for sub in ("sources", "transform", "db", "analyze"):
+        for sub in ("sources", "transform", "query", "schema", "analyze"):
             assert sub in output, f"Expected data subcommand '{sub}' in help output"
 
     def test_data_sources_help(self, cli_runner):

--- a/tests/test_db_command.py
+++ b/tests/test_db_command.py
@@ -1,44 +1,87 @@
-"""Tests for the `tycoon data db` subcommands."""
+"""Tests for `tycoon data query`, `tycoon data schema`, and `tycoon data clean`."""
 
 from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
 
 from tycoon.cli import app
 
 
-class TestDbStats:
+class TestSchema:
 
-    def test_db_stats_runs(self, cli_runner):
-        """data db stats should run even with no databases (shows WARN status)."""
-        result = cli_runner.invoke(app, ["data", "db", "stats"])
+    def test_schema_runs(self, cli_runner):
+        """data schema should run even with no databases (shows WARN status)."""
+        result = cli_runner.invoke(app, ["data", "schema"])
         assert result.exit_code == 0
-        # Should contain some output — either OK or WARN for databases
         assert len(result.stdout) > 0
 
-    def test_db_stats_output_contains_database_labels(self, cli_runner):
-        result = cli_runner.invoke(app, ["data", "db", "stats"])
+    def test_schema_output_contains_database_labels(self, cli_runner):
+        result = cli_runner.invoke(app, ["data", "schema"])
         output = result.stdout
-        # Should mention Raw and Local databases (or equivalent labels)
-        assert "Raw" in output or "raw" in output or "Local" in output or "local" in output
+        assert "Raw" in output or "raw" in output or "Warehouse" in output or "warehouse" in output
 
 
-class TestDbQuery:
+class TestQuery:
 
-    def test_db_query_no_database_gives_error(self, cli_runner, tmp_config, monkeypatch):
+    def test_query_no_database_gives_error(self, cli_runner, tmp_config, monkeypatch):
         """query should fail gracefully when the database file does not exist."""
         monkeypatch.setattr("tycoon.commands.db.config", tmp_config)
-        # Remove the local db if it somehow exists
         if tmp_config.local_db.exists():
             tmp_config.local_db.unlink()
 
-        result = cli_runner.invoke(app, ["data", "db", "query", "SELECT 1"])
+        result = cli_runner.invoke(app, ["data", "query", "SELECT 1"])
         assert result.exit_code != 0
 
+    def test_query_with_db_flag(self, cli_runner, tmp_path):
+        """--db flag should query a specific DuckDB file."""
+        db_path = tmp_path / "test.duckdb"
+        con = duckdb.connect(str(db_path))
+        con.execute("CREATE TABLE t (id INTEGER, name VARCHAR)")
+        con.execute("INSERT INTO t VALUES (1, 'alice'), (2, 'bob')")
+        con.close()
 
-class TestDbHelp:
-
-    def test_db_help(self, cli_runner):
-        result = cli_runner.invoke(app, ["data", "db", "--help"])
+        result = cli_runner.invoke(app, ["data", "query", "SELECT * FROM t", "--db", str(db_path)])
         assert result.exit_code == 0
-        assert "stats" in result.stdout
+        assert "alice" in result.stdout
+        assert "bob" in result.stdout
+
+    def test_query_with_source_flag(self, cli_runner, tmp_path, monkeypatch):
+        """--source flag should find the right raw DB by schema introspection."""
+        from tycoon.config import TycoonConfig
+
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test"\n')
+        (tmp_path / "tycoon.yml").write_text("name: test\nsources: {}\n")
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        db_path = data_dir / "my_raw.duckdb"
+        con = duckdb.connect(str(db_path))
+        con.execute("CREATE SCHEMA raw_myapi")
+        con.execute("CREATE TABLE raw_myapi.items (id INTEGER, val VARCHAR)")
+        con.execute("INSERT INTO raw_myapi.items VALUES (1, 'hello')")
+        con.close()
+
+        cfg = TycoonConfig(project_root=tmp_path)
+        monkeypatch.setattr("tycoon.commands.db.config", cfg)
+
+        result = cli_runner.invoke(app, ["data", "query", "SELECT * FROM raw_myapi.items", "--source", "myapi"])
+        assert result.exit_code == 0
+        assert "hello" in result.stdout
+
+
+class TestDataHelp:
+
+    def test_data_help_shows_query_schema_clean(self, cli_runner):
+        result = cli_runner.invoke(app, ["data", "--help"])
+        assert result.exit_code == 0
         assert "query" in result.stdout
+        assert "schema" in result.stdout
         assert "clean" in result.stdout
+
+    def test_query_help_shows_source_and_db_flags(self, cli_runner):
+        result = cli_runner.invoke(app, ["data", "query", "--help"])
+        assert result.exit_code == 0
+        assert "--source" in result.stdout
+        assert "--db" in result.stdout

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -652,3 +652,39 @@ class TestAnalyzeCLIErrors:
         # Do NOT create the raw db
         result = cli_runner.invoke(app, ["data", "analyze", "my-src"])
         assert result.exit_code != 0
+
+    def test_analyze_interactive_prompt_does_not_crash(self, cli_runner, tmp_path, monkeypatch):
+        """Regression: `tycoon data analyze` without a source argument must
+        present an interactive prompt, not crash with AttributeError from a
+        bad typer.Choice reference. See typer.Choice → click.Choice fix."""
+        monkeypatch.chdir(tmp_path)
+        tycoon_yml = (
+            "name: test\n"
+            "version: 0.1.0\n"
+            "database:\n"
+            "  raw: data/raw.duckdb\n"
+            "  warehouse: data/warehouse.duckdb\n"
+            "sources:\n"
+            "  src_a:\n"
+            "    type: rest_api\n"
+            "    schema: raw_src_a\n"
+        )
+        (tmp_path / "tycoon.yml").write_text(tycoon_yml)
+        (tmp_path / "data").mkdir()
+        con = duckdb.connect(str(tmp_path / "data" / "raw.duckdb"))
+        con.execute("CREATE SCHEMA raw_src_a")
+        con.execute("CREATE TABLE raw_src_a.items (id INTEGER)")
+        con.close()
+
+        # Reload config for the analyze command
+        from tycoon.commands import explore as explore_mod
+        from tycoon.config import TycoonConfig
+        monkeypatch.setattr(explore_mod, "config", TycoonConfig(project_root=tmp_path))
+
+        # Supply "src_a" as the interactive choice
+        result = cli_runner.invoke(app, ["data", "analyze", "--no-dbt"], input="src_a\n")
+        # The key assertion: no AttributeError. Exit may be 0 or non-zero depending
+        # on downstream behavior; we just need the prompt to not crash.
+        assert not isinstance(result.exception, AttributeError), (
+            f"typer.Choice regression: {result.exception!r}\n{result.stdout}"
+        )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -88,14 +88,14 @@ class TestBlankScaffold:
 
     def test_blank_scaffold_via_cli(self, cli_runner, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        # init --name without --template runs the interactive wizard;
-        # supply input to answer the prompts (greenfield path)
+        # Per-component wizard: ingestion=dlt, warehouse=local, dbt=create,
+        # rill=create, orchestrator=dagster
         result = cli_runner.invoke(
             app,
             ["init", "--name", "my-project"],
-            input="n\n1\n\n1\n1\n",  # no pipeline, duckdb, default dbt path, Rill, Dagster
+            input="1\n1\n1\n1\n1\n",
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"init failed: {result.stdout}"
         assert (tmp_path / "tycoon.yml").exists()
 
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,162 @@
+"""Tests for `tycoon register dbt` and `tycoon register rill`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from tycoon.cli import app
+
+
+def _scaffold_tycoon_project(root: Path, name: str = "proj") -> Path:
+    """Create a minimal tycoon.yml in `root` and return the yml path."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "data").mkdir(exist_ok=True)
+    (root / "pyproject.toml").write_text(f'[project]\nname = "{name}"\n')
+    yml = root / "tycoon.yml"
+    yml.write_text(
+        yaml.dump(
+            {
+                "name": name,
+                "version": "0.1.0",
+                "database": {
+                    "raw": "data/raw.duckdb",
+                    "warehouse": "data/warehouse.duckdb",
+                },
+                "sources": {},
+            }
+        )
+    )
+    return yml
+
+
+def _make_dbt_project(dbt_dir: Path, profile: str, duckdb_path: str) -> None:
+    dbt_dir.mkdir(parents=True, exist_ok=True)
+    (dbt_dir / "dbt_project.yml").write_text(
+        yaml.dump({"name": profile, "profile": profile, "config-version": 2})
+    )
+    (dbt_dir / "profiles.yml").write_text(
+        yaml.dump(
+            {
+                profile: {
+                    "target": "dev",
+                    "outputs": {"dev": {"type": "duckdb", "path": duckdb_path}},
+                }
+            }
+        )
+    )
+
+
+def _reload_config(monkeypatch, project_root: Path) -> None:
+    """Rebind the module-level `config` singletons so commands see the new project."""
+    from tycoon.commands import register as register_mod
+    from tycoon.config import TycoonConfig
+
+    cfg = TycoonConfig(project_root=project_root)
+    monkeypatch.setattr(register_mod, "config", cfg)
+
+
+class TestRegisterDbt:
+
+    def test_register_dbt_by_local_path(self, cli_runner, tmp_path, monkeypatch):
+        project = tmp_path / "proj"
+        yml = _scaffold_tycoon_project(project, "proj")
+        dbt_dir = tmp_path / "proj-dbt"
+        _make_dbt_project(dbt_dir, "proj", str(project / "data" / "warehouse.duckdb"))
+
+        monkeypatch.chdir(project)
+        _reload_config(monkeypatch, project)
+        result = cli_runner.invoke(app, ["register", "dbt", str(dbt_dir)], input="\n")
+        assert result.exit_code == 0, result.stdout
+
+        data = yaml.safe_load(yml.read_text())
+        assert "dbt_project_dir" in data
+        assert data["stack"]["transformation"] == "dbt"
+        assert data["stack"]["transformation_managed"] is False
+
+    def test_register_dbt_refuses_nonexistent_path(self, cli_runner, tmp_path, monkeypatch):
+        project = tmp_path / "proj"
+        _scaffold_tycoon_project(project, "proj")
+        monkeypatch.chdir(project)
+        _reload_config(monkeypatch, project)
+        result = cli_runner.invoke(app, ["register", "dbt", "/nowhere/does/not/exist"])
+        assert result.exit_code != 0
+
+    def test_register_dbt_refuses_dir_without_dbt_project_yml(self, cli_runner, tmp_path, monkeypatch):
+        project = tmp_path / "proj"
+        _scaffold_tycoon_project(project, "proj")
+        empty = tmp_path / "not-a-dbt"
+        empty.mkdir()
+        monkeypatch.chdir(project)
+        _reload_config(monkeypatch, project)
+        result = cli_runner.invoke(app, ["register", "dbt", str(empty)])
+        assert result.exit_code != 0
+
+    def test_register_dbt_prompts_on_overwrite(self, cli_runner, tmp_path, monkeypatch):
+        project = tmp_path / "proj"
+        yml = _scaffold_tycoon_project(project, "proj")
+        data = yaml.safe_load(yml.read_text())
+        data["dbt_project_dir"] = "old_dbt"
+        yml.write_text(yaml.dump(data))
+
+        dbt_dir = tmp_path / "proj-dbt"
+        _make_dbt_project(dbt_dir, "proj", str(project / "data" / "warehouse.duckdb"))
+
+        monkeypatch.chdir(project)
+        _reload_config(monkeypatch, project)
+
+        # "n" = don't overwrite
+        result = cli_runner.invoke(app, ["register", "dbt", str(dbt_dir)], input="n\n")
+        assert result.exit_code == 0
+        final = yaml.safe_load(yml.read_text())
+        assert final["dbt_project_dir"] == "old_dbt"
+
+    def test_register_dbt_offers_warehouse_alignment(self, cli_runner, tmp_path, monkeypatch):
+        """If dbt project targets a different DuckDB, offer to adopt it."""
+        project = tmp_path / "proj"
+        _scaffold_tycoon_project(project, "proj")
+
+        dbt_dir = tmp_path / "proj-dbt"
+        divergent = tmp_path / "elsewhere" / "theirs.duckdb"
+        _make_dbt_project(dbt_dir, "proj", str(divergent))
+
+        monkeypatch.chdir(project)
+        _reload_config(monkeypatch, project)
+
+        # First prompt: overwrite? (no existing → no prompt). Warehouse prompt: yes.
+        result = cli_runner.invoke(app, ["register", "dbt", str(dbt_dir)], input="y\n")
+        assert result.exit_code == 0, result.stdout
+
+        data = yaml.safe_load((project / "tycoon.yml").read_text())
+        assert data["database"]["warehouse"] == str(divergent)
+
+
+class TestRegisterRill:
+
+    def test_register_rill_by_local_path(self, cli_runner, tmp_path, monkeypatch):
+        project = tmp_path / "proj"
+        yml = _scaffold_tycoon_project(project, "proj")
+        rill_dir = tmp_path / "proj-rill"
+        rill_dir.mkdir()
+        (rill_dir / "rill.yaml").write_text("compiler: rillv1\n")
+
+        monkeypatch.chdir(project)
+        _reload_config(monkeypatch, project)
+        result = cli_runner.invoke(app, ["register", "rill", str(rill_dir)])
+        assert result.exit_code == 0, result.stdout
+
+        data = yaml.safe_load(yml.read_text())
+        assert "rill_dir" in data
+        assert data["stack"]["bi"] == "rill"
+        assert data["stack"]["bi_managed"] is False
+
+    def test_register_rill_refuses_dir_without_rill_yaml(self, cli_runner, tmp_path, monkeypatch):
+        project = tmp_path / "proj"
+        _scaffold_tycoon_project(project, "proj")
+        empty = tmp_path / "not-a-rill"
+        empty.mkdir()
+        monkeypatch.chdir(project)
+        _reload_config(monkeypatch, project)
+        result = cli_runner.invoke(app, ["register", "rill", str(empty)])
+        assert result.exit_code != 0

--- a/tests/test_templates_smoke.py
+++ b/tests/test_templates_smoke.py
@@ -1,0 +1,70 @@
+"""Smoke tests: `tycoon init --template X` should produce a valid project
+that `tycoon doctor` accepts without errors.
+
+These are init→doctor depth only — they don't run ingestion, dbt, or Rill.
+Source-run smoke tests (which hit the network) live behind an @pytest.mark.e2e
+marker (not present yet; will be added when we add network e2e infra).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tycoon.cli import app
+
+
+TEMPLATES = ["csv-import", "github-analytics", "nyc-transit", "weather-station"]
+
+
+@pytest.mark.parametrize("template", TEMPLATES)
+class TestTemplateSmoke:
+
+    def test_init_creates_tycoon_yml(self, template, cli_runner, tmp_path, monkeypatch):
+        project = tmp_path / template
+        project.mkdir()
+        monkeypatch.chdir(project)
+        result = cli_runner.invoke(app, ["init", "--template", template])
+        assert result.exit_code == 0, f"init --template {template} failed:\n{result.stdout}"
+        assert (project / "tycoon.yml").exists()
+
+    def test_tycoon_yml_parses_and_has_sources(self, template, cli_runner, tmp_path, monkeypatch):
+        project = tmp_path / template
+        project.mkdir()
+        monkeypatch.chdir(project)
+        cli_runner.invoke(app, ["init", "--template", template])
+
+        data = yaml.safe_load((project / "tycoon.yml").read_text())
+        assert "name" in data
+        assert "database" in data
+        assert "sources" in data
+        assert data["sources"], f"template {template} should define at least one source"
+
+    def test_scaffolded_dirs_exist(self, template, cli_runner, tmp_path, monkeypatch):
+        project = tmp_path / template
+        project.mkdir()
+        monkeypatch.chdir(project)
+        cli_runner.invoke(app, ["init", "--template", template])
+
+        assert (project / "data").exists(), f"{template}: data/ not created"
+        assert (project / "rill").exists(), f"{template}: rill/ not created"
+
+    def test_doctor_runs_clean(self, template, cli_runner, tmp_path, monkeypatch):
+        """After init, `tycoon doctor` should exit 0 (warnings ok, no errors)."""
+        project = tmp_path / template
+        project.mkdir()
+        monkeypatch.chdir(project)
+        init_result = cli_runner.invoke(app, ["init", "--template", template])
+        assert init_result.exit_code == 0
+
+        from tycoon.commands import doctor as doctor_mod
+        from tycoon.config import TycoonConfig
+
+        monkeypatch.setattr(doctor_mod, "config", TycoonConfig(project_root=project))
+
+        doctor_result = cli_runner.invoke(app, ["doctor"])
+        assert doctor_result.exit_code == 0, (
+            f"doctor failed for template {template}:\n{doctor_result.stdout}"
+        )

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from tycoon.cli import app
-from tycoon.commands.init import DetectionResults, _detect_existing
+from tycoon.commands.init import (
+    DetectionResults,
+    _detect_existing,
+    _extract_dbt_duckdb_path,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -182,6 +187,80 @@ class TestWizardDetection:
         # Detected path should be recorded; transformation_managed should be False
         # because we're using an existing project rather than scaffolding.
         assert data["stack"]["transformation_managed"] is False
+
+
+class TestExtractDbtDuckdbPath:
+    """_extract_dbt_duckdb_path reads a dbt project's active profile and
+    returns the DuckDB path (or None for non-DuckDB / missing configs)."""
+
+    def _make_dbt_project(self, dbt_dir: Path, profile: str, duckdb_path: str) -> None:
+        dbt_dir.mkdir(parents=True, exist_ok=True)
+        (dbt_dir / "dbt_project.yml").write_text(
+            yaml.dump({"name": profile, "profile": profile, "config-version": 2})
+        )
+        (dbt_dir / "profiles.yml").write_text(
+            yaml.dump(
+                {
+                    profile: {
+                        "target": "dev",
+                        "outputs": {"dev": {"type": "duckdb", "path": duckdb_path}},
+                    }
+                }
+            )
+        )
+
+    def test_returns_absolute_duckdb_path(self, tmp_path: Path) -> None:
+        dbt_dir = tmp_path / "mydbt"
+        wh = tmp_path / "warehouse.duckdb"
+        self._make_dbt_project(dbt_dir, "mine", str(wh))
+        result = _extract_dbt_duckdb_path(dbt_dir)
+        assert result == str(wh)
+
+    def test_resolves_relative_path_against_dbt_dir(self, tmp_path: Path) -> None:
+        dbt_dir = tmp_path / "mydbt"
+        self._make_dbt_project(dbt_dir, "mine", "../warehouse.duckdb")
+        result = _extract_dbt_duckdb_path(dbt_dir)
+        # dbt_dir/../warehouse.duckdb resolves to tmp_path/warehouse.duckdb
+        assert result == str((tmp_path / "warehouse.duckdb").resolve())
+
+    def test_returns_none_for_non_duckdb_target(self, tmp_path: Path) -> None:
+        dbt_dir = tmp_path / "mydbt"
+        dbt_dir.mkdir()
+        (dbt_dir / "dbt_project.yml").write_text(
+            yaml.dump({"name": "mine", "profile": "mine", "config-version": 2})
+        )
+        (dbt_dir / "profiles.yml").write_text(
+            yaml.dump(
+                {
+                    "mine": {
+                        "target": "prod",
+                        "outputs": {"prod": {"type": "snowflake", "account": "x"}},
+                    }
+                }
+            )
+        )
+        assert _extract_dbt_duckdb_path(dbt_dir) is None
+
+    def test_returns_none_when_profiles_missing(self, tmp_path: Path) -> None:
+        dbt_dir = tmp_path / "mydbt"
+        dbt_dir.mkdir()
+        (dbt_dir / "dbt_project.yml").write_text(
+            yaml.dump({"name": "mine", "profile": "mine"})
+        )
+        # Don't write profiles.yml; and ensure ~/.dbt/profiles.yml doesn't exist here
+        # (test may spuriously pass if user has one — but that's orthogonal)
+        # We just assert *this* dir's check returns None given no local profiles.yml.
+        # If the user has a matching ~/.dbt profile, the helper may still return
+        # a value — that's by design.
+        home_profile = Path.home() / ".dbt" / "profiles.yml"
+        if home_profile.exists():
+            pytest.skip("User has ~/.dbt/profiles.yml; can't assert None here")
+        assert _extract_dbt_duckdb_path(dbt_dir) is None
+
+    def test_returns_none_when_dbt_project_yml_missing(self, tmp_path: Path) -> None:
+        dbt_dir = tmp_path / "empty"
+        dbt_dir.mkdir()
+        assert _extract_dbt_duckdb_path(dbt_dir) is None
 
 
 class TestWizardSkipSemantics:

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1,0 +1,210 @@
+"""Tests for the tycoon init wizard: detection + per-component prompts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from tycoon.cli import app
+from tycoon.commands.init import DetectionResults, _detect_existing
+
+
+# ---------------------------------------------------------------------------
+# _detect_existing
+# ---------------------------------------------------------------------------
+
+
+class TestDetectExisting:
+    """Detection tests always run against a subdir so `target.parent` is a
+    controlled space (not the shared pytest session tmpdir)."""
+
+    def test_empty_project_detects_nothing(self, tmp_path: Path) -> None:
+        project = tmp_path / "p"
+        project.mkdir()
+        result = _detect_existing(project)
+        assert isinstance(result, DetectionResults)
+        assert not result.has_any()
+
+    def test_detects_inline_dbt_project(self, tmp_path: Path) -> None:
+        project = tmp_path / "p"
+        project.mkdir()
+        dbt_dir = project / "dbt_project"
+        dbt_dir.mkdir()
+        (dbt_dir / "dbt_project.yml").write_text("name: demo\n")
+
+        result = _detect_existing(project)
+        assert [item.path for item in result.dbt if item.kind == "inline"] == [dbt_dir]
+
+    def test_detects_dbt_in_alt_inline_dirs(self, tmp_path: Path) -> None:
+        project = tmp_path / "p"
+        project.mkdir()
+        (project / "transformation").mkdir()
+        (project / "transformation" / "dbt_project.yml").write_text("name: demo\n")
+
+        result = _detect_existing(project)
+        inline = [item.path for item in result.dbt if item.kind == "inline"]
+        assert inline == [project / "transformation"]
+
+    def test_detects_inline_rill(self, tmp_path: Path) -> None:
+        project = tmp_path / "p"
+        project.mkdir()
+        (project / "rill").mkdir()
+        (project / "rill" / "rill.yaml").write_text("compiler: rillv1\n")
+
+        result = _detect_existing(project)
+        inline = [item for item in result.rill if item.kind == "inline"]
+        assert len(inline) == 1
+
+    def test_detects_sibling_dbt_project(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-project"
+        project.mkdir()
+        sibling = tmp_path / "my-project-dbt"
+        sibling.mkdir()
+        (sibling / "dbt_project.yml").write_text("name: demo\n")
+
+        result = _detect_existing(project)
+        sibling_hits = [item for item in result.dbt if item.kind == "sibling"]
+        assert len(sibling_hits) == 1
+        assert sibling_hits[0].path == sibling
+
+    def test_warehouse_excludes_raw_dbs(self, tmp_path: Path) -> None:
+        project = tmp_path / "p"
+        project.mkdir()
+        data = project / "data"
+        data.mkdir()
+        (data / "warehouse.duckdb").write_text("")
+        (data / "raw.duckdb").write_text("")
+        (data / "raw_pokeapi.duckdb").write_text("")
+        (data / "pokeapi_raw.duckdb").write_text("")
+
+        result = _detect_existing(project)
+        warehouse_names = {item.path.name for item in result.warehouse}
+        assert warehouse_names == {"warehouse.duckdb"}
+
+    def test_hidden_siblings_ignored(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-project"
+        project.mkdir()
+        hidden = tmp_path / ".cache"
+        hidden.mkdir()
+        (hidden / "dbt_project.yml").write_text("name: bad\n")
+
+        result = _detect_existing(project)
+        assert len(result.dbt) == 0
+
+
+# ---------------------------------------------------------------------------
+# Wizard via CLI
+# ---------------------------------------------------------------------------
+
+
+class TestWizardGreenfield:
+
+    def test_default_all_managed(self, cli_runner, tmp_path, monkeypatch):
+        project = tmp_path / "green"
+        project.mkdir()
+        monkeypatch.chdir(project)
+        # ingestion=dlt, warehouse=local, dbt=create, rill=create, orch=dagster
+        result = cli_runner.invoke(
+            app,
+            ["init", "--name", "green"],
+            input="1\n1\n1\n1\n1\n",
+        )
+        assert result.exit_code == 0, result.stdout
+
+        data = yaml.safe_load((project / "tycoon.yml").read_text())
+        assert data["stack"]["ingestion"] == "dlt"
+        assert data["stack"]["ingestion_managed"] is True
+        assert data["stack"]["transformation"] == "dbt"
+        assert data["stack"]["transformation_managed"] is True
+        assert data["stack"]["bi"] == "rill"
+        assert data["stack"]["bi_managed"] is True
+        assert data["stack"]["orchestrator"] == "dagster"
+
+    def test_skip_every_optional_component(self, cli_runner, tmp_path, monkeypatch):
+        project = tmp_path / "skippy"
+        project.mkdir()
+        monkeypatch.chdir(project)
+        # ingestion=skip, warehouse=local, dbt=skip, rill=skip, orch=skip
+        result = cli_runner.invoke(
+            app,
+            ["init", "--name", "skippy"],
+            input="3\n1\n3\n3\n3\n",
+        )
+        assert result.exit_code == 0, result.stdout
+
+        data = yaml.safe_load((project / "tycoon.yml").read_text())
+        assert data["stack"]["ingestion"] == "none"
+        assert data["stack"]["transformation"] == "none"
+        assert data["stack"]["bi"] == "none"
+        assert data["stack"]["orchestrator"] == "none"
+        assert "dbt_project_dir" not in data
+        assert "rill_dir" not in data
+
+    def test_creates_dbt_at_sibling_path(self, cli_runner, tmp_path, monkeypatch):
+        project_dir = tmp_path / "myproj"
+        project_dir.mkdir()
+        monkeypatch.chdir(project_dir)
+        result = cli_runner.invoke(
+            app,
+            ["init", "--name", "myproj"],
+            input="1\n1\n1\n1\n1\n",  # dbt "create" = sibling
+        )
+        assert result.exit_code == 0, result.stdout
+
+        sibling = tmp_path / "myproj-dbt"
+        assert sibling.exists()
+        assert (sibling / "dbt_project.yml").exists()
+        assert (sibling / "profiles.yml").exists()
+
+
+class TestWizardDetection:
+
+    def test_detected_dbt_listed_as_first_option(self, cli_runner, tmp_path, monkeypatch):
+        """When a dbt project exists at a canonical location, wizard offers it as option 1."""
+        project = tmp_path / "myproj"
+        project.mkdir()
+        # Pre-existing dbt project inline
+        dbt = project / "dbt_project"
+        dbt.mkdir()
+        (dbt / "dbt_project.yml").write_text("name: mine\nversion: '1.0.0'\nconfig-version: 2\nprofile: mine\n")
+
+        monkeypatch.chdir(project)
+        # ingestion=dlt, warehouse=local, dbt=1 (detected), rill=1 (create), orch=1
+        result = cli_runner.invoke(
+            app,
+            ["init", "--name", "myproj"],
+            input="1\n1\n1\n1\n1\n",
+        )
+        assert result.exit_code == 0, result.stdout
+
+        data = yaml.safe_load((project / "tycoon.yml").read_text())
+        # Detected path should be recorded; transformation_managed should be False
+        # because we're using an existing project rather than scaffolding.
+        assert data["stack"]["transformation_managed"] is False
+
+
+class TestWizardSkipSemantics:
+
+    def test_doctor_reports_skipped_components(self, cli_runner, tmp_path, monkeypatch):
+        """After skipping dbt + rill + orch, `tycoon doctor` should say 'skipped by choice'."""
+        project = tmp_path / "skippy"
+        project.mkdir()
+        monkeypatch.chdir(project)
+        init_result = cli_runner.invoke(
+            app,
+            ["init", "--name", "skippy"],
+            input="3\n1\n3\n3\n3\n",
+        )
+        assert init_result.exit_code == 0
+
+        # Reload config so doctor sees the new tycoon.yml
+        from tycoon.commands import doctor as doctor_mod
+        from tycoon.config import TycoonConfig
+
+        monkeypatch.setattr(doctor_mod, "config", TycoonConfig(project_root=project))
+
+        doctor_result = cli_runner.invoke(app, ["doctor"])
+        assert doctor_result.exit_code == 0
+        out = doctor_result.stdout
+        assert "skipped by choice" in out

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ wheels = [
 
 [[package]]
 name = "database-tycoon"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "dbt-core" },


### PR DESCRIPTION
## Summary

Cleanup release + a real onboarding wizard. Full details in `docs/releases/v0.1.1.md`.

Key additions:
- Per-component `tycoon init` wizard (ingestion → warehouse → dbt → Rill → orchestrator) with auto-detection, register-existing (path or GitHub URL with clone), and explicit skip.
- `tycoon register dbt` and `tycoon register rill` subcommands.
- `tycoon data query` gains `--source` and `--db` flags. Closes #1.
- Warehouse-alignment check when registering external dbt projects.
- `tycoon data db <sub>` flattened into `tycoon data schema / query / clean`.

Fixes:
- `tycoon data analyze` / `tycoon data sources run` no longer crash with `AttributeError` when invoked without a source argument (`typer.Choice` → `click.Choice`).
- `tycoon doctor` no longer falsely claims `tycoon data analyze` scaffolds dbt.
- `server/check-updates` queries the correct PyPI package.

## Test plan

- [x] Full pytest suite green locally (202 passing, 1 skipped)
- [x] New: 16 template smoke tests, 17 wizard tests, 7 register tests, 1 regression test
- [x] `tycoon --version` returns `0.1.1`
- [x] `tycoon --help` shows `register` in Project section
- [ ] CI runs pytest on this PR
- [ ] After merge + tag: verify publish workflow runs and `database-tycoon==0.1.1` appears on PyPI

Release notes live at `docs/releases/v0.1.1.md`.