### PR TITLE
fix: pass md: URLs through to Nao instead of path-joining

### DIFF
--- a/src/tycoon/nao.py
+++ b/src/tycoon/nao.py
@@ -35,11 +35,22 @@ def build_nao_config(cfg: TycoonConfig) -> dict:
     nao_dir = cfg.nao_dir
     ask = project.ask if project else None
 
-    # Database entry pointing at the warehouse DuckDB
+    # Database entry pointing at the warehouse DuckDB.
+    # For MotherDuck (`md:<catalog>`), pass the URL through verbatim — it's a
+    # valid argument to `duckdb.connect()` and Nao's DuckDBConfig wraps it in
+    # `ibis.duckdb.connect(database=..., read_only=True)` which handles it
+    # natively. A filesystem-relative path would produce a broken
+    # `../../md:<catalog>` string.
+    warehouse_spec = project.database.warehouse if project else None
+    if warehouse_spec and warehouse_spec.startswith("md:"):
+        db_path = warehouse_spec
+    else:
+        db_path = _rel(nao_dir, cfg.local_db)
+
     db_entry: dict = {
         "name": project.name if project else "tycoon-warehouse",
         "type": "duckdb",
-        "path": _rel(nao_dir, cfg.local_db),
+        "path": db_path,
         "accessors": ["columns", "preview"],
         "profiling": {
             "refresh_policy": "interval",

--- a/tests/test_nao.py
+++ b/tests/test_nao.py
@@ -1,0 +1,74 @@
+"""Tests for the Nao config generator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tycoon.config import TycoonConfig
+from tycoon.nao import build_nao_config
+
+
+def _write_project(root: Path, warehouse: str, stack_warehouse: str = "duckdb") -> None:
+    """Write a minimal tycoon.yml at ``root`` with the given warehouse path."""
+    (root / "pyproject.toml").write_text('[project]\nname = "test"\n')
+    (root / "tycoon.yml").write_text(
+        "name: test\n"
+        "version: 0.1.0\n"
+        "database:\n"
+        "  raw: data/raw.duckdb\n"
+        f"  warehouse: {warehouse}\n"
+        "dbt_project_dir: dbt\n"
+        "sources: {}\n"
+        "stack:\n"
+        "  ingestion: dlt\n"
+        "  ingestion_managed: false\n"
+        f"  warehouse: {stack_warehouse}\n"
+        "  transformation: dbt\n"
+        "  transformation_managed: false\n"
+        "  bi: none\n"
+        "  bi_managed: false\n"
+        "  orchestrator: none\n"
+        "  orchestrator_managed: false\n"
+    )
+
+
+class TestBuildNaoConfig:
+
+    def test_local_duckdb_path_is_relative(self, tmp_path: Path):
+        _write_project(tmp_path, warehouse="data/warehouse.duckdb")
+        cfg = TycoonConfig(project_root=tmp_path)
+
+        nao_cfg = build_nao_config(cfg)
+
+        db_path = nao_cfg["databases"][0]["path"]
+        # Relative from .tycoon/nao/ back out to data/warehouse.duckdb
+        assert db_path.endswith("warehouse.duckdb")
+        assert not db_path.startswith("md:")
+
+    def test_motherduck_url_passes_through_verbatim(self, tmp_path: Path):
+        """Regression: `md:<catalog>` must NOT be path-joined. Nao's DuckDB
+        backend accepts the URL as-is via `ibis.duckdb.connect(database=...)`.
+        """
+        _write_project(
+            tmp_path,
+            warehouse="md:my_catalog",
+            stack_warehouse="motherduck",
+        )
+        cfg = TycoonConfig(project_root=tmp_path)
+
+        nao_cfg = build_nao_config(cfg)
+
+        db_path = nao_cfg["databases"][0]["path"]
+        assert db_path == "md:my_catalog"
+
+    def test_no_project_falls_back_to_default_path(self, tmp_path: Path):
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test"\n')
+        cfg = TycoonConfig(project_root=tmp_path)
+
+        nao_cfg = build_nao_config(cfg)
+
+        db_path = nao_cfg["databases"][0]["path"]
+        assert not db_path.startswith("md:")
+        assert db_path.endswith("warehouse.duckdb")


### PR DESCRIPTION
## Summary

`build_nao_config` always constructs the Nao database entry by path-joining `cfg.local_db`, even when `stack.warehouse == motherduck` and `database.warehouse` is a `md:<catalog>` URL. The result is a broken relative string like `../../md:<catalog>` that DuckDB can't open.

This PR detects `md:` URLs and passes them through verbatim. Local-file paths are unchanged.

## Why

`scaffolding/templates.py:128` already writes `database.warehouse: md:<name>` for MotherDuck stacks, so the warehouse field is a URL, not a filesystem path. `duckdb.connect()` and `ibis.duckdb.connect(database=..., read_only=True)` (what Nao's `DuckDBConfig.connect()` calls) both accept `md:<catalog>` as a first-class connection argument. Nao doesn't need any MD-specific awareness — it just needs the URL, not a path-joined mutation of it.

Verified against a live MotherDuck warehouse:

```python
con = ibis.duckdb.connect(database='md:dogfood_dbt_prod', read_only=True)
con.list_databases()                     # ['mart', 'staging', ...]
con.list_tables(database='mart')         # ['mart__time_tracking', ...]
con.sql("SELECT count(*) FROM mart.mart__time_tracking").execute()  # works
```

Nao's sync loop (`nao_core/commands/sync/providers/databases/provider.py:109-125`) calls `get_schemas(conn)` then `list_tables(database=schema)` per schema — both compatible with this flow.

## Diff

```py
# before
"path": _rel(nao_dir, cfg.local_db),

# after
warehouse_spec = project.database.warehouse if project else None
if warehouse_spec and warehouse_spec.startswith("md:"):
    db_path = warehouse_spec
else:
    db_path = _rel(nao_dir, cfg.local_db)
...
"path": db_path,
```

## Test plan

- [x] New `tests/test_nao.py` covers: local path (unchanged), `md:` passthrough, no-project fallback
- [x] `pytest` green (198 passed, 1 skipped across the suite)
- [ ] Manual: `tycoon ask init` on a MotherDuck-backed project now writes `path: md:<catalog>` into `.tycoon/nao/nao_config.yaml`

## Notes / follow-ups

- MotherDuck exposes non-user schemas (`pg_catalog`, `information_schema`, and in our case also `sqlmesh__*` leftovers) via `list_databases()`. Users should scope with `ask.include_schemas` in `tycoon.yml` — supported today via the existing glob-based filter in `nao_core.DatabaseConfig.matches_pattern`. No code change needed here, but worth a doc note.
- Snowflake / BigQuery warehouses still route through `cfg.local_db` — they don't use Nao's DuckDB backend at all. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)