### PR TITLE
fix(v0.1.9): address PR #59 review feedback (robustness polish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ _Headline: Google Sheets source ([#52][]). Plus managed project-local `.venv` + 
 
 ### Fixed
 
-- **Robustness polish from PR review** (PRs [#59][], [#69][]). `tycoon schedule add --command` now tolerates a redundant leading `tycoon` (so `"tycoon data run-all"` doesn't become `tycoon tycoon …`) and rejects an empty command after stripping; Quack detection tries a plain `LOAD quack;` before the network `INSTALL … FROM core_nightly` for offline/cached use, and fast-fails rather than cascading into the 60s install if that probe hangs; `tycoon notify` swallows *any* webhook exception (not just `httpx.HTTPError`) so a malformed URL can't crash a pipeline; the Google Sheets service-account key is read as UTF-8 (Windows safety); and `tycoon notify --field` rejects an empty key.
+- **Robustness polish from PR review** (PRs [#59][], [#69][]). `tycoon schedule add --command` now tolerates a redundant leading `tycoon` (so `"tycoon data run-all"` doesn't become `tycoon tycoon …`) and rejects an empty command after stripping; Quack detection tries a plain `LOAD quack;` before the network `INSTALL … FROM core_nightly` for offline/cached use, and fast-fails rather than cascading into the 60s install if that probe hangs; `tycoon notify` catches every failure `httpx.post` can raise (`httpx.HTTPError` plus `httpx.InvalidURL`) so a malformed URL can't crash a pipeline, without a blanket `except` that would hide real bugs; the Google Sheets service-account key is read as UTF-8 (Windows safety); and `tycoon notify --field` rejects an empty key.
 
 [#31]: https://github.com/Database-Tycoon/tycoon-cli/issues/31
 [#42]: https://github.com/Database-Tycoon/tycoon-cli/issues/42

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ _Headline: Google Sheets source ([#52][]). Plus managed project-local `.venv` + 
 [#55]: https://github.com/Database-Tycoon/tycoon-cli/issues/55
 [#57]: https://github.com/Database-Tycoon/tycoon-cli/issues/57
 [#59]: https://github.com/Database-Tycoon/tycoon-cli/pull/59
+[#69]: https://github.com/Database-Tycoon/tycoon-cli/pull/69
 [#60]: https://github.com/Database-Tycoon/tycoon-cli/issues/60
 [#61]: https://github.com/Database-Tycoon/tycoon-cli/issues/61
 [#65]: https://github.com/Database-Tycoon/tycoon-cli/issues/65

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ _Headline: Google Sheets source ([#52][]). Plus managed project-local `.venv` + 
 - **Fivetran credentials can no longer leak into a committed `tycoon.yml`** ([#60][]). `stack.ingestion_metadata.api_key` / `api_secret` are now `pydantic.SecretStr`, so they mask to `**********` in any `repr`/traceback, and their field docs steer you to `${FIVETRAN_API_SECRET}`-style env-var indirection (the loader already expands `${VAR}` before validation, keeping the literal secret out of the file). `save_project` now preserves the hand-authored `ingestion_metadata` block verbatim on round-trip — previously a `sources add` / `register` write would re-dump the *expanded* secret straight back into `tycoon.yml`. The scaffolded `.gitignore` also now excludes `.env`, `.dlt/secrets.toml`, and `**/profiles.yml` (the files that actually hold credentials); `tycoon.yml` stays committable as the shareable stack template.
 - **SQL identifier injection in Rill export and `data schema` is closed** ([#61][]). Schema/table/column names sourced from `tycoon.yml` or introspected from a DuckDB file are now quoted via a shared `quote_identifier` helper before interpolation into SQL. Previously an attacker-crafted `schema:` value in a shared project could break out of the `COPY … TO` statement that `tycoon data analyze --rill` runs — and DuckDB's `COPY`/`INSTALL` can write files and load extensions, so this was a path to arbitrary file write, not just data disclosure. The export's destination-path literal is escaped too. (The broader `tycoon.yml` identifier/path validation layer is tracked in [#65][].)
 
+### Fixed
+
+- **Robustness polish from PR review** (PR [#59][]). `tycoon schedule add --command` now tolerates a redundant leading `tycoon` (so `"tycoon data run-all"` doesn't become `tycoon tycoon …`); Quack detection tries a plain `LOAD quack;` before the network `INSTALL … FROM core_nightly` for offline/cached use; `tycoon notify` swallows *any* webhook exception (not just `httpx.HTTPError`) so a malformed URL can't crash a pipeline; the Google Sheets service-account key is read as UTF-8 (Windows safety); and `tycoon notify --field` rejects an empty key.
+
 [#31]: https://github.com/Database-Tycoon/tycoon-cli/issues/31
 [#42]: https://github.com/Database-Tycoon/tycoon-cli/issues/42
 [#46]: https://github.com/Database-Tycoon/tycoon-cli/issues/46
@@ -25,6 +29,7 @@ _Headline: Google Sheets source ([#52][]). Plus managed project-local `.venv` + 
 [#52]: https://github.com/Database-Tycoon/tycoon-cli/issues/52
 [#55]: https://github.com/Database-Tycoon/tycoon-cli/issues/55
 [#57]: https://github.com/Database-Tycoon/tycoon-cli/issues/57
+[#59]: https://github.com/Database-Tycoon/tycoon-cli/pull/59
 [#60]: https://github.com/Database-Tycoon/tycoon-cli/issues/60
 [#61]: https://github.com/Database-Tycoon/tycoon-cli/issues/61
 [#65]: https://github.com/Database-Tycoon/tycoon-cli/issues/65

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ _Headline: Google Sheets source ([#52][]). Plus managed project-local `.venv` + 
 
 ### Fixed
 
-- **Robustness polish from PR review** (PR [#59][]). `tycoon schedule add --command` now tolerates a redundant leading `tycoon` (so `"tycoon data run-all"` doesn't become `tycoon tycoon …`); Quack detection tries a plain `LOAD quack;` before the network `INSTALL … FROM core_nightly` for offline/cached use; `tycoon notify` swallows *any* webhook exception (not just `httpx.HTTPError`) so a malformed URL can't crash a pipeline; the Google Sheets service-account key is read as UTF-8 (Windows safety); and `tycoon notify --field` rejects an empty key.
+- **Robustness polish from PR review** (PRs [#59][], [#69][]). `tycoon schedule add --command` now tolerates a redundant leading `tycoon` (so `"tycoon data run-all"` doesn't become `tycoon tycoon …`) and rejects an empty command after stripping; Quack detection tries a plain `LOAD quack;` before the network `INSTALL … FROM core_nightly` for offline/cached use, and fast-fails rather than cascading into the 60s install if that probe hangs; `tycoon notify` swallows *any* webhook exception (not just `httpx.HTTPError`) so a malformed URL can't crash a pipeline; the Google Sheets service-account key is read as UTF-8 (Windows safety); and `tycoon notify --field` rejects an empty key.
 
 [#31]: https://github.com/Database-Tycoon/tycoon-cli/issues/31
 [#42]: https://github.com/Database-Tycoon/tycoon-cli/issues/42

--- a/src/tycoon/commands/notify.py
+++ b/src/tycoon/commands/notify.py
@@ -16,7 +16,11 @@ def _parse_fields(pairs: list[str]) -> dict[str, str]:
             error(f"Invalid --field '{pair}' — expected key=value.")
             raise typer.Exit(2)
         key, value = pair.split("=", 1)
-        out[key.strip()] = value.strip()
+        key = key.strip()
+        if not key:
+            error(f"Invalid --field '{pair}' — key cannot be empty.")
+            raise typer.Exit(2)
+        out[key] = value.strip()
     return out
 
 

--- a/src/tycoon/commands/schedule.py
+++ b/src/tycoon/commands/schedule.py
@@ -64,6 +64,9 @@ def add_schedule(
     # run `tycoon tycoon data run-all` and fail.
     if args and args[0] == "tycoon":
         args = args[1:]
+    if not args:
+        error("--command cannot be empty.")
+        raise typer.Exit(2)
     if notify and "--notify" not in args:
         args.append("--notify")
 

--- a/src/tycoon/commands/schedule.py
+++ b/src/tycoon/commands/schedule.py
@@ -59,6 +59,11 @@ def add_schedule(
         raise typer.Exit(1)
 
     args = shlex.split(command)
+    # Tolerate a redundant leading "tycoon" (e.g. --command "tycoon data run-all")
+    # — the wrapper already invokes the tycoon program, so a kept prefix would
+    # run `tycoon tycoon data run-all` and fail.
+    if args and args[0] == "tycoon":
+        args = args[1:]
     if notify and "--notify" not in args:
         args.append("--notify")
 

--- a/src/tycoon/ingestion/source_manager.py
+++ b/src/tycoon/ingestion/source_manager.py
@@ -152,7 +152,7 @@ def run_pipeline(name, source_config, raw_db_path, max_records=None):
     if creds_path:
         key_file = Path(creds_path).expanduser()
         if key_file.is_file():
-            kwargs["credentials"] = json.loads(key_file.read_text())
+            kwargs["credentials"] = json.loads(key_file.read_text(encoding="utf-8"))
 
     source = google_spreadsheet(**kwargs)
     if max_records:

--- a/src/tycoon/notify.py
+++ b/src/tycoon/notify.py
@@ -111,6 +111,9 @@ def send(
     )
     try:
         response = httpx.post(resolved, json=payload, timeout=timeout)
-    except httpx.HTTPError:
+    except Exception:
+        # Best-effort by contract — swallow anything (httpx.HTTPError, plus
+        # InvalidURL / ValueError from a malformed webhook) so a notification
+        # problem can never crash the calling pipeline.
         return False
     return response.is_success

--- a/src/tycoon/notify.py
+++ b/src/tycoon/notify.py
@@ -111,9 +111,11 @@ def send(
     )
     try:
         response = httpx.post(resolved, json=payload, timeout=timeout)
-    except Exception:
-        # Best-effort by contract — swallow anything (httpx.HTTPError, plus
-        # InvalidURL / ValueError from a malformed webhook) so a notification
-        # problem can never crash the calling pipeline.
+    except (httpx.HTTPError, httpx.InvalidURL):
+        # Best-effort by contract: catch every failure httpx.post can raise —
+        # connect/timeout/protocol errors (all HTTPError) plus InvalidURL from
+        # a malformed webhook — so a notification problem can't crash the
+        # pipeline. Deliberately NOT a blanket `except Exception`, which would
+        # mask genuine bugs (NameError/TypeError) in this path.
         return False
     return response.is_success

--- a/src/tycoon/quack.py
+++ b/src/tycoon/quack.py
@@ -129,6 +129,20 @@ def extension_available() -> bool:
 
     if shutil.which("duckdb") is None:
         return False
+    # Try a plain LOAD first: if the extension is already cached locally this
+    # succeeds offline and skips the network round-trip that INSTALL ... FROM
+    # core_nightly always makes.
+    try:
+        loaded = subprocess.run(
+            ["duckdb", "-c", "LOAD quack;"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if loaded.returncode == 0:
+            return True
+    except (subprocess.TimeoutExpired, OSError):
+        pass
     try:
         result = subprocess.run(
             ["duckdb", "-c", _LOAD_QUACK],

--- a/src/tycoon/quack.py
+++ b/src/tycoon/quack.py
@@ -141,12 +141,12 @@ def extension_available() -> bool:
         )
         if loaded.returncode == 0:
             return True
-    except subprocess.TimeoutExpired:
-        # A timeout on a plain LOAD means duckdb is hanging — don't cascade
-        # into the 60s INSTALL and hang again. Quack is opt-in; fail fast.
+    except (subprocess.TimeoutExpired, OSError):
+        # A timeout or OS-level failure on a plain LOAD (the binary already
+        # exists — we checked `which` above) means duckdb is hanging or
+        # unusable; the 60s INSTALL would hit the same wall. Quack is opt-in
+        # with graceful fallback, so fail fast rather than cascade.
         return False
-    except OSError:
-        pass
     try:
         result = subprocess.run(
             ["duckdb", "-c", _LOAD_QUACK],

--- a/src/tycoon/quack.py
+++ b/src/tycoon/quack.py
@@ -141,7 +141,11 @@ def extension_available() -> bool:
         )
         if loaded.returncode == 0:
             return True
-    except (subprocess.TimeoutExpired, OSError):
+    except subprocess.TimeoutExpired:
+        # A timeout on a plain LOAD means duckdb is hanging — don't cascade
+        # into the 60s INSTALL and hang again. Quack is opt-in; fail fast.
+        return False
+    except OSError:
         pass
     try:
         result = subprocess.run(

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -82,10 +82,13 @@ class TestSend:
         with patch("tycoon.notify.httpx.post", return_value=resp):
             assert notify.send("info", "x", url="https://example.com/h") is False
 
-    def test_returns_false_on_non_httperror_exception(self):
-        # A malformed webhook can make httpx raise ValueError / InvalidURL, not
-        # an HTTPError — send() must still swallow it (never raises by contract).
-        with patch("tycoon.notify.httpx.post", side_effect=ValueError("bad url")):
+    def test_returns_false_on_invalid_url(self):
+        # A malformed webhook makes httpx raise InvalidURL, which is NOT an
+        # HTTPError subclass — send() must still swallow it (never raises by
+        # contract) without resorting to a blanket `except Exception`.
+        import httpx
+
+        with patch("tycoon.notify.httpx.post", side_effect=httpx.InvalidURL("bad")):
             assert notify.send("info", "x", url="https://example.com/h") is False
 
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -82,6 +82,12 @@ class TestSend:
         with patch("tycoon.notify.httpx.post", return_value=resp):
             assert notify.send("info", "x", url="https://example.com/h") is False
 
+    def test_returns_false_on_non_httperror_exception(self):
+        # A malformed webhook can make httpx raise ValueError / InvalidURL, not
+        # an HTTPError — send() must still swallow it (never raises by contract).
+        with patch("tycoon.notify.httpx.post", side_effect=ValueError("bad url")):
+            assert notify.send("info", "x", url="https://example.com/h") is False
+
 
 # ---------------------------------------------------------------------------
 # `tycoon notify` command
@@ -106,6 +112,12 @@ class TestNotifyCommand:
         result = cli_runner.invoke(app, ["notify", "info", "hello", "--field", "noequals"])
         assert result.exit_code == 2
         assert "Invalid --field" in (result.stderr or result.output)
+
+    def test_empty_field_key_exits_2(self, cli_runner, monkeypatch):
+        monkeypatch.setenv(notify.WEBHOOK_ENV_VAR, "https://example.com/h")
+        result = cli_runner.invoke(app, ["notify", "info", "hello", "--field", "=value"])
+        assert result.exit_code == 2
+        assert "key cannot be empty" in (result.stderr or result.output)
 
     def test_success_path_sends(self, cli_runner, monkeypatch):
         monkeypatch.setenv(notify.WEBHOOK_ENV_VAR, "https://example.com/h")

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -274,3 +274,45 @@ class TestDoctorSchedulesRow:
             doctor._check_schedules()
         out = capsys.readouterr().out
         assert "none installed" in out
+
+
+class TestAddCommandPrefixStrip:
+    """The `add` CLI command should tolerate a redundant leading `tycoon`."""
+
+    def test_strips_leading_tycoon_from_command(self, cli_runner, tmp_path):
+        captured = {}
+
+        def fake_add(spec, **_kwargs):
+            captured["args"] = spec.args
+            return "installed"
+
+        with patch("tycoon.commands.schedule.config") as cfg, \
+             patch("tycoon.commands.schedule.sched.list_schedules", return_value=[]), \
+             patch("tycoon.commands.schedule.sched.add", side_effect=fake_add):
+            cfg.has_project_file = True
+            cfg.root = tmp_path
+            result = cli_runner.invoke(
+                app, ["schedule", "add", "daily-refresh", "--command", "tycoon data run-all"]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured["args"] == ["data", "run-all"]
+
+    def test_keeps_command_without_tycoon_prefix(self, cli_runner, tmp_path):
+        captured = {}
+
+        def fake_add(spec, **_kwargs):
+            captured["args"] = spec.args
+            return "installed"
+
+        with patch("tycoon.commands.schedule.config") as cfg, \
+             patch("tycoon.commands.schedule.sched.list_schedules", return_value=[]), \
+             patch("tycoon.commands.schedule.sched.add", side_effect=fake_add):
+            cfg.has_project_file = True
+            cfg.root = tmp_path
+            result = cli_runner.invoke(
+                app, ["schedule", "add", "daily-refresh", "--command", "data run-all"]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured["args"] == ["data", "run-all"]

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -298,6 +298,21 @@ class TestAddCommandPrefixStrip:
         assert result.exit_code == 0, result.output
         assert captured["args"] == ["data", "run-all"]
 
+    def test_empty_command_after_strip_exits_2(self, cli_runner, tmp_path):
+        # "--command tycoon" strips to [] — must be rejected, not scheduled as
+        # a bare `tycoon` that just prints help on a timer.
+        with patch("tycoon.commands.schedule.config") as cfg, \
+             patch("tycoon.commands.schedule.sched.list_schedules", return_value=[]), \
+             patch("tycoon.commands.schedule.sched.add") as add:
+            cfg.has_project_file = True
+            cfg.root = tmp_path
+            result = cli_runner.invoke(
+                app, ["schedule", "add", "daily-refresh", "--command", "tycoon"]
+            )
+        assert result.exit_code == 2, result.output
+        assert "cannot be empty" in (result.stderr or result.output)
+        add.assert_not_called()
+
     def test_keeps_command_without_tycoon_prefix(self, cli_runner, tmp_path):
         captured = {}
 


### PR DESCRIPTION
Folds in the 5 valid findings from Gemini's review of PR #59, into v0.1.9 before the tag is pushed. The lone "high" (uv venv --force not rmtree-ing) was a **false positive** — I verified empirically that `uv venv` already removes and replaces an existing environment.

- **schedule**: strip a redundant leading `tycoon` from `--command`
- **quack**: try plain `LOAD quack;` before the network `INSTALL … FROM core_nightly`
- **notify**: swallow any `httpx.post` exception, not just `HTTPError`
- **google sheets**: read service-account key as UTF-8 (Windows)
- **notify --field**: reject an empty key

+4 tests; full suite 717 passed. CHANGELOG updated under v0.1.9 `### Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Database-Tycoon/codesmith/tycoon-cli/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783767815&installation_id=139583274&pr_number=69&repository=Database-Tycoon%2Ftycoon-cli&return_to=https%3A%2F%2Fgithub.com%2FDatabase-Tycoon%2Ftycoon-cli%2Fpull%2F69&signature=d43d6cd2cd539c7c05291aac45c3d4cea90b080b29b77bf1886fb58b216cd0b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->