### PR TITLE
docs: propose native DuckLake layered storage (SQLite-catalog)

### DIFF
--- a/docs/proposals/ducklake-layered-storage.md
+++ b/docs/proposals/ducklake-layered-storage.md
@@ -76,6 +76,8 @@ outputs:
 
 Models materialize with `{{ config(database='mart', schema='main') }}`; sources point at `database: raw`.
 
+> **Version floor — this is native in dbt-duckdb ≥ 1.10, not older.** The `is_ducklake` and `options` fields on `attach:` are declared on dbt-duckdb's `Attachment` model as of 1.10 and were exercised end-to-end on **1.10.1** in spike 4 (a real `dbt run` materialized into the mart catalog). On **older** dbt-duckdb the `Attachment` model rejects them (`extra fields not permitted`) and you'd need a custom `plugins:` adapter instead — so the implementation must **pin a dbt-duckdb floor**, not assume the syntax works everywhere.
+
 ### How it maps to the current code
 
 | Today | Becomes |
@@ -93,7 +95,7 @@ Models materialize with `{{ config(database='mart', schema='main') }}`; sources 
 
 ## Open questions / decisions needed
 
-1. **Default vs opt-in.** Is layered-DuckLake *the* warehouse model, or an opt-in "lakehouse mode"? Given no users yet ([no-legacy stance]) there's no compat tax either way. **Recommendation:** prototype it *behind* the existing `raw`/`warehouse` abstraction so the CLI surface is unchanged, validate it carries the conference demo, then commit.
+1. **Default vs opt-in.** Is layered-DuckLake *the* warehouse model, or an opt-in "lakehouse mode"? Given no users yet (the project's no-legacy stance) there's no compat tax either way. **Recommendation:** prototype it *behind* the existing `raw`/`warehouse` abstraction so the CLI surface is unchanged, validate it carries the conference demo, then commit.
 2. **Catalog backend default + graduation.** SQLite by default (local, multi-process). Document the swap to PostgreSQL / MotherDuck for multi-machine sharing — same Parquet, different metadata home. PostgreSQL catalog is explicitly **later**, not this work.
 3. **Schema naming.** In spike 4, dbt turned `schema: main` into `main_main` (default `generate_schema_name` concatenates target + custom). The implementation must override `generate_schema_name` or set layer schemas deliberately.
 4. **The one unproven leg: S3.** Every spike used a *local* `data_path`. `data_path: s3://…` is untested. MinIO would mean Docker (against local-first), so validate against a real bucket before claiming "S3-ready." **This is a prerequisite to the S3 phase.**

--- a/docs/proposals/ducklake-layered-storage.md
+++ b/docs/proposals/ducklake-layered-storage.md
@@ -76,6 +76,8 @@ outputs:
 
 Models materialize with `{{ config(database='mart', schema='main') }}`; sources point at `database: raw`.
 
+> **Why `raw` omits `data_path` but `mart` includes it.** A DuckLake catalog stores its `data_path` in metadata at **creation time**, so re-attaching an *existing* catalog doesn't need it. `raw` is pre-created by ingestion (dlt), so it re-attaches with just `read_only: true`; `mart` is created here, so it specifies `data_path`. Verified: re-attaching an existing `ducklake:sqlite:` catalog with no `data_path` resolves and reads correctly.
+
 > **Version floor — this is native in dbt-duckdb ≥ 1.10, not older.** The `is_ducklake` and `options` fields on `attach:` are declared on dbt-duckdb's `Attachment` model as of 1.10 and were exercised end-to-end on **1.10.1** in spike 4 (a real `dbt run` materialized into the mart catalog). On **older** dbt-duckdb the `Attachment` model rejects them (`extra fields not permitted`) and you'd need a custom `plugins:` adapter instead — so the implementation must **pin a dbt-duckdb floor**, not assume the syntax works everywhere.
 
 ### How it maps to the current code

--- a/docs/proposals/ducklake-layered-storage.md
+++ b/docs/proposals/ducklake-layered-storage.md
@@ -1,0 +1,133 @@
+# Proposal: native DuckLake layered storage (SQLite-catalog)
+
+_Status: drafted 2026-06-21 from a spike investigation (4 spikes, all green). **Not scheduled** and **not part of v0.1.10** (the security pass). This is a storage-engine proposal for a future minor. It revives the DuckLake track deferred since v0.1.7 ([#31][], open) with new evidence, and builds on — does not replace — the **already-shipped** layer-aware data model ([#30][], closed): #30 delivered the *logical* layers, this adds an optional *physical* backing for them._
+
+## TL;DR
+
+Give each warehouse layer its own **DuckLake catalog** (SQLite metadata file + Parquet data), composed in one DuckDB session via `ATTACH`. dbt reads the `raw` catalog read-only and materializes into the `mart` catalog. Point each layer's `data_path` at `s3://…` and the same setup becomes a local-first lakehouse on object storage — no catalog server, no Docker. This is the credible local-first answer to "can we serve something like Polaris locally?": you don't serve a catalog, you open one.
+
+The investigation also **corrects a factual error in shipped docs** (`docs/commands/data/analyze.md:68`) about why the Parquet bridge for Rill exists.
+
+## How we got here
+
+Started from two user questions: "how are we integrating with S3?" and "can we serve something like Polaris locally?" Following the thread led to DuckLake (catalog-as-a-database, only data on object storage), which raised the old objection that killed DuckLake for Rill in v0.1.3 — an exclusive-lock conflict while ingesting. We spiked it to find out whether that objection still holds.
+
+## What the spikes proved
+
+All scripts live in the session scratchpad (throwaway) and are reproducible; verified against DuckDB 1.5.3, ducklake ext `e6a3bd0a`, Rill 0.86, dbt-duckdb 1.10.1 / dbt-core 1.11.8.
+
+| # | Question | Result |
+|---|---|---|
+| 1 | Front DuckLake with Quack to dodge the lock? | ❌ **They don't compose.** Quack proxies a native `.duckdb`'s tables, but an `ATTACH`ed DuckLake catalog is invisible to Quack clients. Treat Quack and DuckLake as orthogonal. |
+| 2 | Which catalog backend actually locks? | **DuckDB-backed `.ducklake` locks** (process-exclusive file lock); **SQLite-backed does not** — a held-open READ_ONLY reader + a continuous writer ran clean and the reader saw new snapshots. Deterministic across runs. |
+| 3 | Does the **real Rill** binary survive ingest on a SQLite catalog? | ✅ A Rill project with `olap_connector: lake` on a `ducklake:sqlite:` catalog reconciled and served **live-growing** aggregation counts (100 → 36,100) during ingest, **0 lock conflicts**. |
+| 4 | Does **dbt** work raw-catalog → mart-catalog end-to-end? | ✅ `dbt run` read a READ_ONLY `raw` DuckLake catalog and materialized a model **into** a `mart` DuckLake catalog (3 snapshots, correct data) purely via `profiles.yml` `attach:`. |
+
+## The corrected lock model (supersedes `analyze.md:68`)
+
+`docs/commands/data/analyze.md:68` says the Parquet bridge exists because *"SQLite-backed DuckLake catalogs hold an exclusive lock that breaks Rill-while-ingesting."* **This is wrong on the backend.** The lock is a property of the **catalog metadata database**, not of DuckLake or of SQLite:
+
+- **DuckDB-backed catalog** (`ducklake:foo.ducklake`, the default) — a `.ducklake` file *is* a DuckDB database, and DuckDB locks a database file to one process. Two processes → `Conflicting lock`. **This is what the original v0.1.3 probe actually hit** — its attach string was `ducklake:.../catalog.ducklake` (no `sqlite:` prefix), i.e. DuckDB-backed, while being labeled "SQLite-backed."
+- **SQLite-backed catalog** (`ducklake:sqlite:foo.sqlite`) — SQLite is built for multi-process access (shared read locks; brief exclusive lock only at commit). Reader + writer coexist.
+- **PostgreSQL-backed** — also multi-process safe, but it's a server (breaks local-first).
+
+**Consequence:** the Parquet bridge is **not required** for live Rill dashboards if the catalog is SQLite-backed. (The bridge can remain as a fallback, but it stops being the only option.)
+
+## Proposed architecture
+
+One DuckLake catalog per layer. Metadata (SQLite) stays local; data (Parquet) is local *or* on object storage — a one-line swap.
+
+```
+data/
+  raw.sqlite     mart.sqlite          ← catalog metadata, always local (multi-process safe)
+  raw_data/      mart_data/           ← Parquet — swap to s3://bucket/raw|mart/ via httpfs
+```
+
+Composed in one session:
+
+```sql
+INSTALL ducklake; LOAD ducklake; INSTALL sqlite; LOAD sqlite;
+ATTACH 'ducklake:sqlite:data/raw.sqlite'  AS raw  (DATA_PATH 'data/raw_data/',  READ_ONLY);
+ATTACH 'ducklake:sqlite:data/mart.sqlite' AS mart (DATA_PATH 'data/mart_data/');
+-- a dbt model is just: CREATE TABLE mart.main.x AS SELECT ... FROM raw.main.y
+```
+
+### Validated dbt profile shape
+
+dbt-duckdb 1.10.1's `Attachment` supports this natively (`path='ducklake:sqlite:…'`, `read_only`, `is_ducklake`, `options={data_path: …}` → emits `DATA_PATH '…'`):
+
+```yaml
+outputs:
+  dev:
+    type: duckdb
+    path: ":memory:"
+    extensions: [ducklake, sqlite, httpfs]
+    attach:
+      - path: "ducklake:sqlite:/abs/data/raw.sqlite"
+        alias: raw
+        read_only: true
+        is_ducklake: true
+      - path: "ducklake:sqlite:/abs/data/mart.sqlite"
+        alias: mart
+        is_ducklake: true
+        options: { data_path: "/abs/data/mart_data/" }   # ← or "s3://bucket/mart/"
+    # + a secrets: block for S3 creds when data_path goes remote
+```
+
+Models materialize with `{{ config(database='mart', schema='main') }}`; sources point at `database: raw`.
+
+### How it maps to the current code
+
+| Today | Becomes |
+|---|---|
+| `DatabaseConfig` — two fixed fields `raw` / `warehouse` (`src/tycoon/project.py:141`) | a named map of layers, each `{metadata path, data_path, read/write}` |
+| `ingestion/ducklake_config.py` — **misnamed**: claims DuckLake, actually dumps plain Parquet via dlt's `filesystem` destination | a real per-layer `ATTACH 'ducklake:sqlite:…'` |
+| `observability_dbt.attach_metadata_to_profiles` — emits `{path, alias, read_only}` | emit the DuckLake attach list above |
+| dlt destination → `raw.duckdb` file (`config.raw_db`) | dlt writes into the `raw` DuckLake catalog |
+
+## Relationship to prior decisions
+
+- **#30 (layer-aware data model) is orthogonal and complementary.** #30 is about *logical* layers — classification flowing from dbt folders / dlt / Fivetran, surfaced in `tycoon data status`, with **no `layers:` block in `tycoon.yml`** (classification authority lives in the tools). This proposal is about *physical* storage. They compose cleanly: the logical layers map onto physical DuckLake catalogs. This proposal must **respect #30's "no classification config" principle** — the only new config here is physical (which catalog file / data_path backs each layer), and even that can stay convention-derived.
+- **#31 (DuckLake backup) gets simpler and is the natural home.** Backup becomes "snapshot the catalog SQLite DB + sync the Parquet prefix," per layer — cleaner than today's opaque `.duckdb`-file copy. The DuckLake docs flag two edges to design around: run compaction/cleanup *before* a manual backup (they rewrite/remove data files), and transactions after a metadata snapshot aren't recoverable from it. The `backup.skip_raw` / `backup.layers` shape from the #31 discussion still applies.
+- **Supersedes the Parquet-bridge rationale** in `analyze.md:68` (correct the doc), without necessarily deleting the bridge.
+
+## Open questions / decisions needed
+
+1. **Default vs opt-in.** Is layered-DuckLake *the* warehouse model, or an opt-in "lakehouse mode"? Given no users yet ([no-legacy stance]) there's no compat tax either way. **Recommendation:** prototype it *behind* the existing `raw`/`warehouse` abstraction so the CLI surface is unchanged, validate it carries the conference demo, then commit.
+2. **Catalog backend default + graduation.** SQLite by default (local, multi-process). Document the swap to PostgreSQL / MotherDuck for multi-machine sharing — same Parquet, different metadata home. PostgreSQL catalog is explicitly **later**, not this work.
+3. **Schema naming.** In spike 4, dbt turned `schema: main` into `main_main` (default `generate_schema_name` concatenates target + custom). The implementation must override `generate_schema_name` or set layer schemas deliberately.
+4. **The one unproven leg: S3.** Every spike used a *local* `data_path`. `data_path: s3://…` is untested. MinIO would mean Docker (against local-first), so validate against a real bucket before claiming "S3-ready." **This is a prerequisite to the S3 phase.**
+
+## Non-goals
+
+- Running or emulating Apache Polaris / an Iceberg REST catalog locally (server + Docker; against local-first).
+- DuckLake ↔ Iceberg interop / foreign engines (Spark/Trino/Snowflake on the same tables) — relevant only if multi-engine demand appears; out of scope here.
+- PostgreSQL catalog backend (the multi-machine tier) — documented as the graduation path, not built now.
+
+## Proposed phasing
+
+- **Phase 0 (now, cheap):** file the issues below; correct `analyze.md:68`; rename/flag the misleading `ducklake_config.py`.
+- **Phase 1:** validate `data_path: s3://…` against a real bucket (the one open risk).
+- **Phase 2:** real `ducklake:sqlite:` ATTACH in `ducklake_config.py`, behind the existing `raw`/`warehouse` abstraction (opt-in).
+- **Phase 3:** generalize `DatabaseConfig` to N layers; extend dbt profile generation; fix `generate_schema_name`.
+- **Phase 4:** fold in backup (#31) and an optional Rill live-connector path (retire/relegate the Parquet bridge).
+
+## Risks
+
+- **DuckLake maturity** — younger than Iceberg/Delta; pin versions and keep the plain-`.duckdb` path available as a fallback.
+- **Single-machine ceiling** — SQLite catalog is local; multi-machine needs the PostgreSQL tier (documented, not built).
+- **S3 unproven** (see Phase 1).
+- **dbt schema-name generation** quirk (see decisions #3).
+
+## Issues (filed 2026-06-22)
+
+1. **[#71][]** (`documentation`) — `analyze.md:68` mislabels the DuckLake lock as SQLite-backed; it's the DuckDB-file backend. Real Rill 0.86 reads a `ducklake:sqlite:` catalog during ingest with no lock. (Evidence: spikes 2 & 3.)
+2. **[#72][]** (`tech-debt`) — `ingestion/ducklake_config.py` claims DuckLake but only dumps plain Parquet via dlt's `filesystem` destination — make it actually `ATTACH 'ducklake:sqlite:…'` or rename.
+3. **[#73][]** (`enhancement`) — tracking issue for this physical-storage design (builds on the shipped #30, unblocks #31).
+
+[#71]: https://github.com/Database-Tycoon/tycoon-cli/issues/71
+[#72]: https://github.com/Database-Tycoon/tycoon-cli/issues/72
+[#73]: https://github.com/Database-Tycoon/tycoon-cli/issues/73
+
+[#30]: https://github.com/Database-Tycoon/tycoon-cli/issues/30
+[#31]: https://github.com/Database-Tycoon/tycoon-cli/issues/31

--- a/docs/proposals/ducklake-layered-storage.md
+++ b/docs/proposals/ducklake-layered-storage.md
@@ -61,6 +61,7 @@ outputs:
   dev:
     type: duckdb
     path: ":memory:"
+    schema: main
     extensions: [ducklake, sqlite, httpfs]
     attach:
       - path: "ducklake:sqlite:/abs/data/raw.sqlite"


### PR DESCRIPTION
## What

Adds `docs/proposals/ducklake-layered-storage.md` — a storage-engine proposal for giving each warehouse layer its own **DuckLake catalog** (SQLite metadata + Parquet, S3-able), composed via `ATTACH`; dbt reads `raw` read-only and materializes into `mart`.

Docs-only. **Not part of v0.1.10** (the security pass) — proposal for a future minor.

## Why

Came out of a 4-spike investigation (all green; DuckDB 1.5.3, ducklake `e6a3bd0a`, real Rill 0.86, dbt-duckdb 1.10.1). Headline finding **corrects shipped docs** (`docs/commands/data/analyze.md:68`): the read-while-ingest lock that justified the Parquet bridge for Rill is a property of the **catalog metadata backend** (DuckDB-file locks per-process), **not** of DuckLake or SQLite. A SQLite-backed catalog supports live Rill reads during ingest — confirmed with the real Rill binary, 0 lock conflicts.

## Validated

- Quack and DuckLake do **not** compose (fronting DuckLake with Quack ruled out).
- DuckDB-file catalog backend locks; **SQLite is multi-process safe**.
- Real Rill 0.86 reads a `ducklake:sqlite:` catalog live during ingest, 0 conflicts.
- dbt-duckdb materializes `raw`-catalog → `mart`-catalog via `profiles.yml` `attach:`.

## Relationship

- Builds on the shipped layer-aware data model (#30) — *logical* layers; this adds an optional *physical* backing. Respects "no `layers:` block."
- Unblocks layer-granular backup (#31).
- Tracks: #73 (this design), #71 (analyze.md fix), #72 (`ducklake_config.py` is misnamed).

## Open risk

`data_path: s3://…` is unproven (all spikes used local paths) — gated as Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Database-Tycoon/codesmith/tycoon-cli/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784755533&installation_id=139583274&pr_number=74&repository=Database-Tycoon%2Ftycoon-cli&return_to=https%3A%2F%2Fgithub.com%2FDatabase-Tycoon%2Ftycoon-cli%2Fpull%2F74&signature=07a7ee969cc1f9dee18e0be0dc06201a9525ebe7dedbdbb9ebfb731ab9c9248d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->