### PR TITLE
docs(proposal): rewrite foundations — manifesto, architecture, plan

### DIFF
--- a/docs/proposals/_tycoon/ARCHITECTURE.md
+++ b/docs/proposals/_tycoon/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Tycoon CLI Architecture
 
-> **Naming note.** This document was drafted in conversation, during which the author used `dbty` / `dbty-cli` as personal shorthand for **Database Tycoon** — the company behind this project. The tool itself is the **Tycoon CLI** (the `tycoon-cli` repository, distributed on PyPI as `database-tycoon`). Any occurrence of `dbty` below refers to this same tool; it is **not** a separate product, not a fork of dbt, and not affiliated with dlt. The shorthand is preserved in places where rewriting would obscure the original framing.
+> **Naming note.** This document was originally drafted using `dbty` / `dbty-cli` as shorthand for **Database Tycoon** and the Tycoon CLI. Names are now reconciled: the tool is **tycoon** (CLI command), `src/tycoon/` (package), `tycoon.yml` (manifest), `.tycoon/` (metadata dir).
 
 > The structural counterpart to [MANIFESTO.md](./MANIFESTO.md). The manifesto says *why* and *what shape*. This document says *how it is built* — from the system boundary down to the source tree.
 >
@@ -16,14 +16,14 @@ These hold across every level. If a design choice violates one of these, it is w
 2. **The cockpit default principle holds in code too.** Every adapter point has a default backing that the beginner gets for free, and a pluggable seam where the user attaches their own. This is true for Runtime (default: dlt-native), for Destination (default: local DuckDB), for Metadata (default: local DuckDB file). The architecture must make the default path and the attached path indistinguishable from the caller's point of view.
 3. **The model is canonical, not the rendering.** No Surface owns truth. The CLI is one renderer of the underlying model. The metadata store *is* the model. Every command resolves to "read or write the model"; the rendering is a thin transform on top.
 4. **No private doors.** A future adapter (sling, Airbyte, dbt-cloud, MotherDuck-as-metadata-backing) must reach what it needs through the same interface the POC adapters use. Special cases are bugs.
-5. **Control-plane shape, always.** dbty addresses; it does not absorb. If a design choice has us *owning* something the user already has (their warehouse, their auth, their dbt project, their scheduler), it is platform-drift and we reject it. See manifesto §1.
+5. **Control-plane shape, always.** tycoon addresses; it does not absorb. If a design choice has us *owning* something the user already has (their warehouse, their auth, their dbt project, their scheduler), it is platform-drift and we reject it. See manifesto §1.
 6. **Scaffolding is silent, minimum, create-only, once.** When `attach` scaffolds, it writes the minimum, in the user's idiom, into empty space, exactly once. It never touches existing files. It is never exposed as its own verb. See manifesto §9.
 
 ---
 
 ## Level 1 — System Context
 
-> Who and what does dbty interact with? Where is the boundary?
+> Who and what does tycoon interact with? Where is the boundary?
 
 ### Actors and external systems
 
@@ -37,7 +37,7 @@ These hold across every level. If a design choice violates one of these, it is w
                                  ▼
                         ┌─────────────────────┐
                         │                     │      ┌─────────────────┐
-        ┌───────────────│        dbty         │◀────▶│ Analytics agent │
+        ┌───────────────│        tycoon         │◀────▶│ Analytics agent │
         │               │   (control plane)   │      │  (LLM client    │
         │               │                     │      │   via MCP/JSON) │
         │               └─────────────────────┘      └─────────────────┘
@@ -65,23 +65,23 @@ These hold across every level. If a design choice violates one of these, it is w
                                 └────────────────────┘
 ```
 
-### What dbty owns
+### What tycoon owns
 
 - The coordination and observation layer between actors above.
 - A small amount of bookkeeping (metadata events, source declarations, catalog snapshots, capability state).
 - The Surfaces: CLI today, JSON output, MCP / TUI / web later — all renderings of the same model.
 
-### What dbty does not own (BYOS boundary)
+### What tycoon does not own (BYOS boundary)
 
-- **The ingestion runtime.** dlt is a library dbty calls; Fivetran is a service dbty talks to.
-- **The user's dlt project or dbt project.** dbty wraps them via entrypoint; they remain authored, version-controlled, and owned by the user.
-- **The Destination.** dbty connects to it; it does not provision, host, or replatform it.
-- **Authentication for the user's stack.** OAuth tokens, API keys, warehouse credentials — held by the user (env vars, their secret manager, the runtime's own config), referenced by dbty.
-- **A long-lived daemon process.** No background dbty service. Every command is invocation-scoped. See Level 2.
+- **The ingestion runtime.** dlt is a library tycoon calls; Fivetran is a service tycoon talks to.
+- **The user's dlt project or dbt project.** tycoon wraps them via entrypoint; they remain authored, version-controlled, and owned by the user.
+- **The Destination.** tycoon connects to it; it does not provision, host, or replatform it.
+- **Authentication for the user's stack.** OAuth tokens, API keys, warehouse credentials — held by the user (env vars, their secret manager, the runtime's own config), referenced by tycoon.
+- **A long-lived daemon process.** No background tycoon service. Every command is invocation-scoped. See Level 2.
 
 ### The boundary in one sentence
 
-dbty is the smallest piece of software that can answer "what is in your stack, what state is it in, and what can I do with it?" — without owning any of the stack itself.
+tycoon is the smallest piece of software that can answer "what is in your stack, what state is it in, and what can I do with it?" — without owning any of the stack itself.
 
 ---
 
@@ -93,11 +93,11 @@ dbty is the smallest piece of software that can answer "what is in your stack, w
 
 The POC is one Python CLI process, invoked per command, terminated when the command returns. No daemon. No background scheduler. No long-lived server.
 
-This is a deliberate choice. A daemon is platform-shape: it implies dbty *runs the show*. An invocation-scoped CLI is control-plane-shape: dbty acts when asked, observes what's there, writes its bookkeeping, exits.
+This is a deliberate choice. A daemon is platform-shape: it implies tycoon *runs the show*. An invocation-scoped CLI is control-plane-shape: tycoon acts when asked, observes what's there, writes its bookkeeping, exits.
 
 ```
    ┌─────────────────────────────────────────────────────────────┐
-   │                  dbty CLI process (per invocation)          │
+   │                  tycoon CLI process (per invocation)          │
    │                                                             │
    │   ┌─────────────┐    ┌──────────────┐   ┌───────────────┐   │
    │   │  Command    │───▶│  Core model  │──▶│   Surface     │   │
@@ -127,14 +127,14 @@ Metadata is an **abstract substrate** with a pluggable backing. The Metadata API
 
 | Backing | Status | Notes |
 |---|---|---|
-| Local DuckDB file (`.dbty/metadata.duckdb`) | **Default, POC.** | Cockpit default. dbty's own bookkeeping; not the user's data. Lives in the project directory next to the dbty manifest. |
-| User's Destination (managed schema, e.g. `_dbty_metadata.*`) | Designed-for, post-POC. | The "graduate to your warehouse" path. Attached explicitly; the user opts in. Same API, different driver. |
+| Local DuckDB file (`.tycoon/metadata.duckdb`) | **Default, POC.** | Cockpit default. tycoon's own bookkeeping; not the user's data. Lives in the project directory next to the tycoon manifest. |
+| User's Destination (managed schema, e.g. `_tycoon_metadata.*`) | Designed-for, post-POC. | The "graduate to your warehouse" path. Attached explicitly; the user opts in. Same API, different driver. |
 
 The Metadata API is designed against the second case from day one and *implemented* against the first. This is the architectural commitment that prevents a future rewrite: the contract holds for both backings; the POC just ships one driver.
 
 #### Project manifest
 
-A small declarative file at the project root (working name `dbty.yml`) holding:
+A small declarative file at the project root (`tycoon.yml`) holding:
 
 - attached Runtimes
 - attached Destinations
@@ -142,16 +142,16 @@ A small declarative file at the project root (working name `dbty.yml`) holding:
 - environment profiles (Source→Runtime/Destination rebindings)
 - the metadata backing choice (defaults to local file)
 
-This is *configuration*, not *state*. State lives in the Metadata backend. The manifest is what the user (or `dbty attach`) edits; it is human-readable and agent-editable.
+This is *configuration*, not *state*. State lives in the Metadata backend. The manifest is what the user (or `tycoon attach`) edits; it is human-readable and agent-editable.
 
 #### Credentials
 
-Not owned by dbty. References live in the manifest as env-var interpolations (`${FIVETRAN_API_KEY}`), TOML paths (`.dlt/secrets.toml`), or runtime-native handles. dbty does not store secrets, and the architecture explicitly forbids a "dbty secret store" — that would be platform-shape (see manifesto §6).
+Not owned by tycoon. References live in the manifest as env-var interpolations (`${FIVETRAN_API_KEY}`), TOML paths (`.dlt/secrets.toml`), or runtime-native handles. tycoon does not store secrets, and the architecture explicitly forbids a "tycoon secret store" — that would be platform-shape (see manifesto §6).
 
 ### External systems, summarized
 
 - **dlt** — Python library imported in-process. Runs synchronously inside the CLI invocation.
-- **Fivetran** — REST API. dbty makes HTTP calls; nothing executes locally.
+- **Fivetran** — REST API. tycoon makes HTTP calls; nothing executes locally.
 - **User's dlt project** — invoked via entrypoint. May run in-process or in a subprocess for isolation (open question, deferred to Level 3).
 - **User's dbt project** — invoked as a subprocess (`dbt run ...`). Always out-of-process.
 - **User's Rill project** (POC Presentation adapter) — invoked as a subprocess (`rill build` / `rill refresh ...`). Reads from the same Destination dbt writes to.
@@ -330,9 +330,9 @@ If a future symmetric compartment (e.g. data-quality testing tools — Great Exp
 ### Proposed top-level layout
 
 ```
-src/dbty/
+src/tycoon/
   __init__.py
-  __main__.py                 # entrypoint: `python -m dbty`
+  __main__.py                 # entrypoint: `python -m tycoon`
   cli.py                      # Typer app, top-level command groups
 
   core/
@@ -378,18 +378,18 @@ src/dbty/
 
   metadata_backends/
     __init__.py               # adapter registry
-    duckdb_file.py            # POC default, .dbty/metadata.duckdb
+    duckdb_file.py            # POC default, .tycoon/metadata.duckdb
     destination.py            # writes into the user's Destination (designed-for, not POC)
 
   surfaces/
     __init__.py
     cli/
       __init__.py
-      source.py               # `dbty source ...`
-      runtime.py              # `dbty runtime ...` (advanced only, hidden from beginner)
-      catalog.py              # `dbty catalog ...`
-      attach.py               # `dbty attach ...`
-      run.py                  # `dbty run ...`
+      source.py               # `tycoon source ...`
+      runtime.py              # `tycoon runtime ...` (advanced only, hidden from beginner)
+      catalog.py              # `tycoon catalog ...`
+      attach.py               # `tycoon attach ...`
+      run.py                  # `tycoon run ...`
       status.py
     json/
       __init__.py
@@ -400,14 +400,14 @@ src/dbty/
 
   scaffolds/
     __init__.py               # scaffolder registry
-    manifest.py               # writes the greenfield dbty.yml + .dbty/ directory
+    manifest.py               # writes the greenfield tycoon.yml + .tycoon/ directory
     dlt_native.py             # writes a minimal starter dlt source skeleton
     dbt.py                    # writes a minimal dbt_project.yml + dirs (POC)
     rill.py                   # writes a minimal Rill project (POC)
     # All scaffolders: create-only, idiom-native, never mutate existing files.
 
   templates/
-    dbty.yml.jinja            # consumed by scaffolds/manifest.py
+    tycoon.yml.jinja          # consumed by scaffolds/manifest.py
     # Per-adapter templates live next to their scaffolder in scaffolds/_templates/
 
 tests/
@@ -446,7 +446,7 @@ This is the same dependency-direction rule as Dango's layered hierarchy, but tig
 - **Adding a new Scaffolder** (e.g. for sqlmesh or Metabase greenfield setup): one new file in `scaffolds/`. Same rule. Invoked silently by `attach`, never exposed as its own command.
 - **Adding a new Metadata backing** (e.g. MotherDuck-as-metadata): one new file in `metadata_backends/`. No changes to `core/metadata.py`'s public API.
 - **Adding a new Surface** (e.g. MCP server): one new package in `surfaces/`. Reads the same core model, renders differently. Zero adapter changes.
-- **Adding a new command verb** (e.g. `dbty backfill`): a new module in `surfaces/cli/`. Calls into `core/`. The core may grow a new method, but it grows the same method for every adapter type simultaneously.
+- **Adding a new command verb** (e.g. `tycoon backfill`): a new module in `surfaces/cli/`. Calls into `core/`. The core may grow a new method, but it grows the same method for every adapter type simultaneously.
 
 This is the architectural acceptance test from manifesto §8 made concrete at the file level. The pattern is the same across four adapter folders (`runtimes/`, `transformations/`, `semantics/`, `presentations/`) — which is exactly what makes the abstraction worth its weight.
 
@@ -455,7 +455,7 @@ This is the architectural acceptance test from manifesto §8 made concrete at th
 1. **`commands/` vs. `surfaces/cli/` for command files.** Both are defensible. `surfaces/cli/` puts CLI logic inside the Surface boundary (cleaner under the manifesto). `commands/` reads more naturally to contributors. Lean toward `surfaces/cli/`; revisit after a few commands exist.
 2. **Adapter registration mechanism.** Entry points (pluggable, future-friendly) or static imports (simpler, current). Probably static for the POC; entry points when a third party wants to ship an adapter.
 3. **Where the project manifest schema lives.** Inside `core/project.py` as Pydantic models, or in a separate `core/schema/` package. Defer until the manifest grows beyond ~5 fields.
-4. **Naming.** `dbty` as the import name vs. `database_tycoon`. The PyPI name is `database-tycoon`. The CLI command is `dbty`. The Python package import should probably be `dbty` for ergonomics, with `database_tycoon` as an alias. Confirm.
+4. **Python import name.** The CLI command is `tycoon` and the package is `src/tycoon/`. The PyPI distribution is `database-tycoon`. Confirm that `import tycoon` is the right ergonomic choice, or whether `database_tycoon` (matching PyPI) should be canonical with `tycoon` as the alias.
 
 ---
 

--- a/docs/proposals/_tycoon/ARCHITECTURE.md
+++ b/docs/proposals/_tycoon/ARCHITECTURE.md
@@ -1,0 +1,479 @@
+# Tycoon CLI Architecture
+
+> **Naming note.** This document was drafted in conversation, during which the author used `dbty` / `dbty-cli` as personal shorthand for **Database Tycoon** — the company behind this project. The tool itself is the **Tycoon CLI** (the `tycoon-cli` repository, distributed on PyPI as `database-tycoon`). Any occurrence of `dbty` below refers to this same tool; it is **not** a separate product, not a fork of dbt, and not affiliated with dlt. The shorthand is preserved in places where rewriting would obscure the original framing.
+
+> The structural counterpart to [MANIFESTO.md](./MANIFESTO.md). The manifesto says *why* and *what shape*. This document says *how it is built* — from the system boundary down to the source tree.
+>
+> Organised by the [C4 model](https://c4model.com/): four altitudes of zoom, each answering a different question. Diagrams are ASCII-first so the document is readable cold, in a terminal, by a human or an agent.
+
+---
+
+## Architectural commitments
+
+These hold across every level. If a design choice violates one of these, it is wrong even if it works.
+
+1. **Abstractions and consistent APIs are non-negotiable.** Every compartment in §7 of the manifesto exposes the same shape of interface. Every concrete backing — runtime, metadata store, destination, catalog source — slots in as an adapter behind that interface. New adapters cause zero core changes.
+2. **The cockpit default principle holds in code too.** Every adapter point has a default backing that the beginner gets for free, and a pluggable seam where the user attaches their own. This is true for Runtime (default: dlt-native), for Destination (default: local DuckDB), for Metadata (default: local DuckDB file). The architecture must make the default path and the attached path indistinguishable from the caller's point of view.
+3. **The model is canonical, not the rendering.** No Surface owns truth. The CLI is one renderer of the underlying model. The metadata store *is* the model. Every command resolves to "read or write the model"; the rendering is a thin transform on top.
+4. **No private doors.** A future adapter (sling, Airbyte, dbt-cloud, MotherDuck-as-metadata-backing) must reach what it needs through the same interface the POC adapters use. Special cases are bugs.
+5. **Control-plane shape, always.** dbty addresses; it does not absorb. If a design choice has us *owning* something the user already has (their warehouse, their auth, their dbt project, their scheduler), it is platform-drift and we reject it. See manifesto §1.
+6. **Scaffolding is silent, minimum, create-only, once.** When `attach` scaffolds, it writes the minimum, in the user's idiom, into empty space, exactly once. It never touches existing files. It is never exposed as its own verb. See manifesto §9.
+
+---
+
+## Level 1 — System Context
+
+> Who and what does dbty interact with? Where is the boundary?
+
+### Actors and external systems
+
+```
+                        ┌─────────────────┐
+                        │   User          │
+                        │   (engineer,    │
+                        │    analyst)     │
+                        └────────┬────────┘
+                                 │  CLI invocations
+                                 ▼
+                        ┌─────────────────────┐
+                        │                     │      ┌─────────────────┐
+        ┌───────────────│        dbty         │◀────▶│ Analytics agent │
+        │               │   (control plane)   │      │  (LLM client    │
+        │               │                     │      │   via MCP/JSON) │
+        │               └─────────────────────┘      └─────────────────┘
+        │                  │     │     │     │
+        │                  ▼     ▼     ▼     ▼
+        │           ┌────────┐ ┌──────────┐ ┌────────────┐ ┌──────────┐
+        │           │  dlt   │ │ Fivetran │ │  User's    │ │  User's  │
+        │           │ (lib)  │ │  (API)   │ │  dlt       │ │  dbt     │
+        │           │        │ │          │ │  project   │ │  project │
+        │           └────┬───┘ └────┬─────┘ └─────┬──────┘ └─────┬────┘
+        │                │          │             │              │
+        │                │          │             │   ┌────────────┐ ┌────────────────┐
+        │                │          │             │   │  User's    │ │  User's        │
+        │                │          │             │   │  Rill /    │ │  Semantic      │
+        │                │          │             │   │  BI tool   │ │  engine (post- │
+        │                │          │             │   │            │ │  POC, optional)│
+        │                │          │             │   └─────┬──────┘ └────────┬───────┘
+        │                │          │             │         │                 │
+        │                └──────────┴──────┬──────┴─────────┴─────────────────┘
+        │                                  ▼
+        │                       ┌────────────────────┐
+        └──────────────────────▶│   Destination      │
+                                │ (DuckDB / Snow /   │
+                                │  BigQuery / ...)   │
+                                └────────────────────┘
+```
+
+### What dbty owns
+
+- The coordination and observation layer between actors above.
+- A small amount of bookkeeping (metadata events, source declarations, catalog snapshots, capability state).
+- The Surfaces: CLI today, JSON output, MCP / TUI / web later — all renderings of the same model.
+
+### What dbty does not own (BYOS boundary)
+
+- **The ingestion runtime.** dlt is a library dbty calls; Fivetran is a service dbty talks to.
+- **The user's dlt project or dbt project.** dbty wraps them via entrypoint; they remain authored, version-controlled, and owned by the user.
+- **The Destination.** dbty connects to it; it does not provision, host, or replatform it.
+- **Authentication for the user's stack.** OAuth tokens, API keys, warehouse credentials — held by the user (env vars, their secret manager, the runtime's own config), referenced by dbty.
+- **A long-lived daemon process.** No background dbty service. Every command is invocation-scoped. See Level 2.
+
+### The boundary in one sentence
+
+dbty is the smallest piece of software that can answer "what is in your stack, what state is it in, and what can I do with it?" — without owning any of the stack itself.
+
+---
+
+## Level 2 — Containers
+
+> What actually runs? Processes, libraries, data stores.
+
+### Process model: single-process, invocation-scoped
+
+The POC is one Python CLI process, invoked per command, terminated when the command returns. No daemon. No background scheduler. No long-lived server.
+
+This is a deliberate choice. A daemon is platform-shape: it implies dbty *runs the show*. An invocation-scoped CLI is control-plane-shape: dbty acts when asked, observes what's there, writes its bookkeeping, exits.
+
+```
+   ┌─────────────────────────────────────────────────────────────┐
+   │                  dbty CLI process (per invocation)          │
+   │                                                             │
+   │   ┌─────────────┐    ┌──────────────┐   ┌───────────────┐   │
+   │   │  Command    │───▶│  Core model  │──▶│   Surface     │   │
+   │   │  dispatcher │    │  (compart-   │   │   renderer    │   │
+   │   │             │    │   ments)     │   │  (CLI / JSON) │   │
+   │   └─────────────┘    └──────┬───────┘   └───────────────┘   │
+   │                             │                               │
+   │                             ▼                               │
+   │                  ┌────────────────────┐                     │
+   │                  │  Adapter layer     │                     │
+   │                  │  ─ Runtime         │                     │
+   │                  │  ─ Destination     │                     │
+   │                  │  ─ Metadata store  │                     │
+   │                  │  ─ Catalog source  │                     │
+   │                  └──┬───────┬─────┬───┘                     │
+   └─────────────────────│───────│─────│─────────────────────────┘
+                         │       │     │
+                         ▼       ▼     ▼
+                 (external systems and local files)
+```
+
+### Data stores
+
+#### Metadata backend (substrate, abstract)
+
+Metadata is an **abstract substrate** with a pluggable backing. The Metadata API is the same regardless of where events and snapshots live.
+
+| Backing | Status | Notes |
+|---|---|---|
+| Local DuckDB file (`.dbty/metadata.duckdb`) | **Default, POC.** | Cockpit default. dbty's own bookkeeping; not the user's data. Lives in the project directory next to the dbty manifest. |
+| User's Destination (managed schema, e.g. `_dbty_metadata.*`) | Designed-for, post-POC. | The "graduate to your warehouse" path. Attached explicitly; the user opts in. Same API, different driver. |
+
+The Metadata API is designed against the second case from day one and *implemented* against the first. This is the architectural commitment that prevents a future rewrite: the contract holds for both backings; the POC just ships one driver.
+
+#### Project manifest
+
+A small declarative file at the project root (working name `dbty.yml`) holding:
+
+- attached Runtimes
+- attached Destinations
+- declared Sources (with Runtime binding and handle)
+- environment profiles (Source→Runtime/Destination rebindings)
+- the metadata backing choice (defaults to local file)
+
+This is *configuration*, not *state*. State lives in the Metadata backend. The manifest is what the user (or `dbty attach`) edits; it is human-readable and agent-editable.
+
+#### Credentials
+
+Not owned by dbty. References live in the manifest as env-var interpolations (`${FIVETRAN_API_KEY}`), TOML paths (`.dlt/secrets.toml`), or runtime-native handles. dbty does not store secrets, and the architecture explicitly forbids a "dbty secret store" — that would be platform-shape (see manifesto §6).
+
+### External systems, summarized
+
+- **dlt** — Python library imported in-process. Runs synchronously inside the CLI invocation.
+- **Fivetran** — REST API. dbty makes HTTP calls; nothing executes locally.
+- **User's dlt project** — invoked via entrypoint. May run in-process or in a subprocess for isolation (open question, deferred to Level 3).
+- **User's dbt project** — invoked as a subprocess (`dbt run ...`). Always out-of-process.
+- **User's Rill project** (POC Presentation adapter) — invoked as a subprocess (`rill build` / `rill refresh ...`). Reads from the same Destination dbt writes to.
+- **User's semantic engine** (post-POC) — dbt MetricFlow, Cube, Malloy, etc. Adapter-specific; either subprocess invocation or HTTP to a running engine.
+- **Destination** — accessed via the relevant SDK/driver (duckdb, snowflake-connector-python, etc.).
+
+### What is explicitly not a container
+
+- No web server.
+- No background worker.
+- No message queue.
+- No managed service of any kind.
+
+These belong to platforms. If a feature in the future seems to need one, the architecture review starts with "can we model this as an invocation instead?"
+
+---
+
+## Level 3 — Components
+
+> Inside the CLI process, what are the modules and what does each do?
+
+This level translates the §7 compartments of the manifesto into code-level components, plus the supporting modules that make them work.
+
+### The compartment-to-component map
+
+| Manifesto compartment | Primary component | Responsibility |
+|---|---|---|
+| Source | `core.source` | Domain model of a Source: identity, runtime binding, handle, declared capabilities. Pure data + validation. |
+| Runtime | `core.runtime` + `runtimes/*` adapters | The Runtime interface plus one concrete adapter per backing (dlt, fivetran, dlt-project). |
+| Destination | `core.destination` + `destinations/*` adapters | The Destination interface plus drivers (duckdb default; others pluggable). |
+| Transformation | `core.transformation` + `transformations/*` adapters | dbt-project wrapper for the POC. Runtime-shaped from day one so sqlmesh / dbt-cloud slot in as new adapter files. |
+| Semantics | `core.semantics` + `semantics/*` adapters | **Post-POC.** The Semantics interface plus pluggable engines (dbt MetricFlow, Cube, Malloy, ...). Folder exists empty during POC so the dependency graph is honest. |
+| Presentation | `core.presentation` + `presentations/*` adapters | The Presentation interface plus pluggable tools. **Rill is the POC adapter**; Metabase / Superset / Lightdash / Hex follow. |
+| Catalog | `core.catalog` | Federated query layer over Runtime / Transformation / Semantics / Presentation offers and Project declarations. Cache-aware. |
+| Metadata | `core.metadata` + `metadata_backends/*` | The Metadata API (events, snapshots, queries). DuckDB-file backing for POC; warehouse backing designed-for. |
+| Surface | `surfaces/cli` + `surfaces/json` | CLI (Typer) and structured-JSON renderers over the core model. Future: `surfaces/mcp`, `surfaces/tui`. |
+
+Supporting components (no manifesto compartment, but load-bearing):
+
+| Component | Responsibility |
+|---|---|
+| `core.project` | Reads/writes the project manifest. Resolves environment bindings. The "what is configured" entrypoint. |
+| `core.capabilities` | The capability model itself — what `can_run`, `can_backfill`, `can_introspect_schema`, etc. mean, and how adapters declare them. |
+| `core.events` | The Metadata event schema. Every action emits one of these. Adapters do not invent event shapes. |
+| `core.identifiers` | Naming, IDs, qualified references (e.g. `source:stripe@fivetran`). Stable string forms an agent can use as keys. |
+| `core.scaffold` + `scaffolds/*` | The Scaffolder interface and per-target scaffolders. Invoked by `attach` on greenfield. Strictly create-only, never user-facing as its own verb. |
+| `commands/*` | Command implementations (`add`, `list`, `attach`, `run`, `status`, ...). Thin: they parse intent, call the core, hand the result to a Surface. |
+
+### Adapter interface shapes (sketch, not final)
+
+The architecture's heaviest commitment is the adapter contracts. Each is a Python Protocol (or ABC) with a small surface; concrete backings implement it. Note the symmetry between Runtime, Transformation, Semantics, and Presentation — they share the *shape* (`capabilities`, `catalog_offers`, `introspect`, `run`, `observe`) even though they point at different downstream artifacts.
+
+```
+Runtime          (Source-side execution)
+  .id                              -> str
+  .capabilities(source) -> set[Capability]
+  .catalog_offers()     -> Iterable[CatalogOffer]      # what this Runtime can produce
+  .introspect(source)   -> SchemaSnapshot               # current schema, freshness
+  .run(source, opts)    -> RunHandle                    # raises CapabilityError if not granted
+  .observe(run_handle)  -> Iterable[RunEvent]           # stream of structured events
+  .read_state()         -> Iterable[RunRecord]          # historical runs (Fivetran API, dlt _dlt_loads)
+
+TransformationAdapter   (warehouse → warehouse)
+  .id                              -> str
+  .capabilities(model)  -> set[Capability]
+  .catalog_offers()     -> Iterable[ModelOffer]         # models the project exposes
+  .introspect(model)    -> ModelSnapshot                # lineage upstream + downstream, freshness
+  .run(model, opts)     -> RunHandle
+  .observe(run_handle)  -> Iterable[RunEvent]
+
+SemanticsAdapter (post-POC; warehouse → meaning)
+  .id                              -> str
+  .capabilities(metric) -> set[Capability]
+  .catalog_offers()     -> Iterable[MetricOffer]        # metrics/dimensions/entities the engine exposes
+  .introspect(metric)   -> MetricSnapshot               # upstream models, dimensions, joins
+  .query(metric, opts)  -> QueryResult                  # the actual metric value(s)
+  .observe(query_h)     -> Iterable[QueryEvent]
+
+PresentationAdapter   (warehouse → consumed view)
+  .id                              -> str
+  .capabilities(view)   -> set[Capability]
+  .catalog_offers()     -> Iterable[ViewOffer]          # dashboards / reports / notebooks
+  .introspect(view)     -> ViewSnapshot                 # upstream models / metrics, freshness, deploy status
+  .run(view, opts)      -> RunHandle                    # build / refresh / deploy
+  .observe(run_handle)  -> Iterable[RunEvent]
+
+Destination
+  .id                              -> str
+  .ping()                          -> HealthStatus
+  .read(query)          -> Rows                         # SELECT path
+  .write(table, rows)   -> WriteResult                  # used by Metadata-on-Destination backing
+  .introspect()         -> WarehouseSchema              # lists schemas/tables for landing/freshness
+
+MetadataBackend
+  .append_event(event)             -> None
+  .query_events(filter)            -> Iterable[Event]
+  .upsert_snapshot(kind, key, blob)-> None
+  .read_snapshot(kind, key)        -> blob | None
+  # Same contract whether backing is local DuckDB file or user's Destination.
+
+CatalogSource     (internal, not a user-facing adapter)
+  .offers(scope)        -> Iterable[CatalogOffer]
+  # One CatalogSource per attached Runtime / Transformation / Semantics / Presentation,
+  # plus one for the Project (declared Sources / Models / Metrics / Views).
+```
+
+If a future symmetric compartment (e.g. data-quality testing tools — Great Expectations, Soda, Elementary) gets added, it inherits the same shape: `capabilities`, `catalog_offers`, `introspect`, `run`/`query`, `observe`. The shape is now load-bearing across four compartments — strong evidence that the abstraction is real, not coincidence.
+
+### Component diagram (in-process)
+
+```
+                         ┌─────────────────────────────────┐
+                         │           commands/             │
+                         │  add  attach  list  run  status │
+                         └────────────────┬────────────────┘
+                                          │
+                                          ▼
+   ┌──────────────────────────────────────────────────────────────────────┐
+   │                              core/                                   │
+   │                                                                      │
+   │   project ──▶ source ──▶ capabilities                                │
+   │                  │                                                   │
+   │                  ▼                                                   │
+   │   ┌─ runtime ──┐  ┌─ transformation ─┐  ┌─ semantics ─┐ ┌─ presentation ─┐
+   │   │ (interface)│  │  (interface)     │  │ (interface) │ │  (interface)   │
+   │   └─────┬──────┘  └────────┬─────────┘  └──────┬──────┘ └────────┬───────┘
+   │         │                  │                   │                 │
+   │         └──────┬───────────┴───────────┬───────┴─────────────────┘
+   │                ▼                       ▼
+   │           ┌─ destination ─┐      ┌─ catalog ─┐
+   │           │  (interface)  │      │           │
+   │           └───────┬───────┘      └─────┬─────┘
+   │                   │                    │
+   │                   └───────── events ◀──┴─── metadata (interface)
+   │                                                                      │
+   └────────────────────────────┬─────────────────────────────────────────┘
+                                │
+   ┌─────────────────┬──────────┴──────────┬──────────────────┐
+   ▼                 ▼                     ▼                  ▼
+┌──────────────┐ ┌─────────────────┐ ┌──────────────┐ ┌─────────────────┐
+│  runtimes/   │ │ transformations/│ │  semantics/  │ │ presentations/  │
+│ ─ dlt        │ │ ─ dbt           │ │ (empty in    │ │ ─ rill (POC)    │
+│ ─ dlt_project│ │ ─ (sqlmesh,     │ │  POC; dbt_mf,│ │ ─ (metabase,    │
+│ ─ fivetran   │ │    dbt_cloud..) │ │  cube, malloy│ │    superset..)  │
+└──────────────┘ └─────────────────┘ │  to follow)  │ └─────────────────┘
+                                     └──────────────┘
+
+   ┌──────────────────┐    ┌─────────────────────────┐
+   │  destinations/   │    │   metadata_backends/    │
+   │  ─ duckdb        │    │   ─ duckdb_file (POC)   │
+   │  ─ ...           │    │   ─ destination (later) │
+   └──────────────────┘    └─────────────────────────┘
+                                                  │
+                        ┌─────────────────────────┴─────────────────┐
+                        ▼                                           ▼
+              ┌──────────────────┐                        ┌─────────────────┐
+              │  surfaces/cli    │                        │ surfaces/json   │
+              │  (Typer)         │                        │ (structured     │
+              │                  │                        │  output)        │
+              └──────────────────┘                        └─────────────────┘
+```
+
+### Component-level open questions
+
+1. **dlt-project Runtime: in-process or subprocess?** In-process is faster and simpler but couples dlt versions; subprocess gives isolation at the cost of complexity. Likely subprocess for safety, but defer until we have a real user project to test against.
+2. **Where does environment resolution happen?** `core.project` resolves Source→Runtime binding for the active environment, but the Source object itself probably shouldn't carry the resolution — it should carry the *declaration*, with resolution as a lookup. Confirm before Level 4.
+3. **Catalog cache lifetime.** Per-invocation? Persisted in Metadata? Probably per-invocation for the POC (simpler, no staleness questions), persisted later with explicit refresh commands.
+4. **Transformation's depth in the POC.** Manifesto says it's a compartment. Code-wise it might be thin enough in the POC to be a single module wrapping `dbt run` invocations and writing events. Revisit when Transformation gets its second backing (sqlmesh, dbt-cloud).
+
+---
+
+## Level 4 — Code (source tree)
+
+> How is this organised on disk? Where does a contributor or an agent find their footing?
+
+### Proposed top-level layout
+
+```
+src/dbty/
+  __init__.py
+  __main__.py                 # entrypoint: `python -m dbty`
+  cli.py                      # Typer app, top-level command groups
+
+  core/
+    __init__.py
+    project.py                # manifest read/write, environment resolution
+    source.py                 # Source dataclass + validation
+    runtime.py                # Runtime protocol + capability declarations
+    destination.py            # Destination protocol
+    catalog.py                # federated query layer
+    metadata.py               # MetadataBackend protocol + Metadata API
+    events.py                 # event schema (Pydantic models)
+    capabilities.py           # Capability enum + capability set helpers
+    identifiers.py            # qualified IDs, parsing, formatting
+    transformation.py         # TransformationAdapter protocol
+    semantics.py              # SemanticsAdapter protocol (post-POC; interface lives in POC)
+    presentation.py           # PresentationAdapter protocol
+    errors.py                 # CapabilityError, AdapterError, etc.
+
+  runtimes/
+    __init__.py               # adapter registry
+    dlt_native.py             # dlt verified sources, in-process
+    dlt_project.py            # user's dlt project, entrypoint-driven
+    fivetran.py               # Fivetran REST API client
+
+  transformations/
+    __init__.py               # adapter registry
+    dbt.py                    # POC: local dbt project subprocess
+    # sqlmesh.py, dbt_cloud.py, ... (post-POC)
+
+  semantics/
+    __init__.py               # adapter registry (empty in POC; folder exists so layering is honest)
+    # dbt_metricflow.py, cube.py, malloy.py, ... (post-POC)
+
+  presentations/
+    __init__.py               # adapter registry
+    rill.py                   # POC: local Rill project subprocess
+    # metabase.py, superset.py, lightdash.py, hex.py, ... (post-POC)
+
+  destinations/
+    __init__.py               # adapter registry
+    duckdb.py                 # default local DuckDB
+    # snowflake.py, bigquery.py, ... (post-POC)
+
+  metadata_backends/
+    __init__.py               # adapter registry
+    duckdb_file.py            # POC default, .dbty/metadata.duckdb
+    destination.py            # writes into the user's Destination (designed-for, not POC)
+
+  surfaces/
+    __init__.py
+    cli/
+      __init__.py
+      source.py               # `dbty source ...`
+      runtime.py              # `dbty runtime ...` (advanced only, hidden from beginner)
+      catalog.py              # `dbty catalog ...`
+      attach.py               # `dbty attach ...`
+      run.py                  # `dbty run ...`
+      status.py
+    json/
+      __init__.py
+      schemas.py              # the JSON shapes agents consume
+      render.py               # core-model -> JSON
+
+  commands/                   # alternative: collapse into surfaces/cli; see open Qs
+
+  scaffolds/
+    __init__.py               # scaffolder registry
+    manifest.py               # writes the greenfield dbty.yml + .dbty/ directory
+    dlt_native.py             # writes a minimal starter dlt source skeleton
+    dbt.py                    # writes a minimal dbt_project.yml + dirs (POC)
+    rill.py                   # writes a minimal Rill project (POC)
+    # All scaffolders: create-only, idiom-native, never mutate existing files.
+
+  templates/
+    dbty.yml.jinja            # consumed by scaffolds/manifest.py
+    # Per-adapter templates live next to their scaffolder in scaffolds/_templates/
+
+tests/
+  unit/
+  integration/
+  e2e/
+
+docs/
+  ...
+
+MANIFESTO.md
+ARCHITECTURE.md               # this document
+README.md
+pyproject.toml
+```
+
+### Layering rules (enforced)
+
+These are the dependency rules that keep the architecture honest. They are checked manually for now; we may codify them with `import-linter` or similar later.
+
+| Layer | Can import |
+|---|---|
+| `core/` | Only stdlib + Pydantic + Jinja (for `core.scaffold` template loading). **Never** `runtimes/`, `transformations/`, `semantics/`, `presentations/`, `destinations/`, `metadata_backends/`, `scaffolds/`, `surfaces/`. |
+| `runtimes/`, `transformations/`, `semantics/`, `presentations/`, `destinations/`, `metadata_backends/`, `scaffolds/` | `core/` + their specific third-party clients. **Never** each other. **Never** `surfaces/`. |
+| `surfaces/` | `core/` + adapter registries (to invoke). **Never** the inside of an adapter. |
+| `cli.py` / `__main__.py` | Anything. The composition root. |
+
+This is the same dependency-direction rule as Dango's layered hierarchy, but tighter — adapters cannot reach across to each other, and Surfaces cannot reach into adapter internals.
+
+### Where new things go (the "no private doors" test)
+
+- **Adding a new Runtime** (e.g. sling, Airbyte): one new file in `runtimes/`. No changes to `core/`. If `core/` needs to change, the Runtime interface is wrong and we fix the interface first.
+- **Adding a new Transformation adapter** (e.g. sqlmesh, dbt-cloud): one new file in `transformations/`. Same rule.
+- **Adding a new Semantics adapter** (e.g. dbt MetricFlow, Cube, Malloy): one new file in `semantics/`. Same rule.
+- **Adding a new Presentation adapter** (e.g. Metabase, Superset, Lightdash, Hex): one new file in `presentations/`. Same rule.
+- **Adding a new Scaffolder** (e.g. for sqlmesh or Metabase greenfield setup): one new file in `scaffolds/`. Same rule. Invoked silently by `attach`, never exposed as its own command.
+- **Adding a new Metadata backing** (e.g. MotherDuck-as-metadata): one new file in `metadata_backends/`. No changes to `core/metadata.py`'s public API.
+- **Adding a new Surface** (e.g. MCP server): one new package in `surfaces/`. Reads the same core model, renders differently. Zero adapter changes.
+- **Adding a new command verb** (e.g. `dbty backfill`): a new module in `surfaces/cli/`. Calls into `core/`. The core may grow a new method, but it grows the same method for every adapter type simultaneously.
+
+This is the architectural acceptance test from manifesto §8 made concrete at the file level. The pattern is the same across four adapter folders (`runtimes/`, `transformations/`, `semantics/`, `presentations/`) — which is exactly what makes the abstraction worth its weight.
+
+### Code-level open questions
+
+1. **`commands/` vs. `surfaces/cli/` for command files.** Both are defensible. `surfaces/cli/` puts CLI logic inside the Surface boundary (cleaner under the manifesto). `commands/` reads more naturally to contributors. Lean toward `surfaces/cli/`; revisit after a few commands exist.
+2. **Adapter registration mechanism.** Entry points (pluggable, future-friendly) or static imports (simpler, current). Probably static for the POC; entry points when a third party wants to ship an adapter.
+3. **Where the project manifest schema lives.** Inside `core/project.py` as Pydantic models, or in a separate `core/schema/` package. Defer until the manifest grows beyond ~5 fields.
+4. **Naming.** `dbty` as the import name vs. `database_tycoon`. The PyPI name is `database-tycoon`. The CLI command is `dbty`. The Python package import should probably be `dbty` for ergonomics, with `database_tycoon` as an alias. Confirm.
+
+---
+
+## How to use this document
+
+- **When starting a new feature**, identify which compartment(s) it touches in §7 of the manifesto, then which components in Level 3 here. If a feature touches `core/` and a specific adapter, the feature is likely splittable into a contract change (in `core/`) and an adapter change (in the adapter).
+- **When adding a new adapter**, jump to Level 4's "no private doors" test. If the answer is "this needs a change to `core/`," the interface is the bug, not the adapter.
+- **When reviewing a PR**, the layering rules in Level 4 are checkable by eye. Imports flowing the wrong way are an architectural smell, not a style nit.
+
+## Status
+
+This document reflects the architectural conversation as of 2026-06-18, paired with [MANIFESTO.md](./MANIFESTO.md). Levels 1 and 2 are decisions we've taken; Levels 3 and 4 are sketches with named open questions, to be sharpened as we build the CLI surface and the first adapters.
+
+Open architectural threads:
+- The exact Runtime / Transformation / Semantics / Presentation interface signatures (Level 3 sketches need to become actual Protocols, with shared shape where possible — see "common adapter shape" question below).
+- Metadata event schema (named in §3 manifesto open threads).
+- The capability model — how an adapter declares what a Source *could* do vs. what it *currently can* do given clearance.
+- Subprocess isolation for `dlt-project` Runtime.
+- **Common adapter shape.** Runtime, Transformation, Semantics, Presentation share `capabilities`, `catalog_offers`, `introspect`, `run`/`query`, `observe`. Do we factor a `Adapter` base Protocol they all extend, or keep them as four independent interfaces that happen to be symmetric? Premature unification can be worse than honest duplication. Defer until we have at least one adapter in each folder.
+- Transformation has a real POC adapter (dbt); Semantics has an interface only (no adapters in POC) — confirm the empty `semantics/` folder approach beats deferring the interface entirely.
+- Whether Presentation's lineage-introspection capability (what does this dashboard read?) should resolve through Destination introspection or through the Presentation adapter's native API. Probably the latter (Rill knows its own lineage best); confirm with the first Rill adapter.

--- a/docs/proposals/_tycoon/MANIFESTO.md
+++ b/docs/proposals/_tycoon/MANIFESTO.md
@@ -1,16 +1,16 @@
 # Tycoon CLI Manifesto
 
-> **Naming note.** This document was drafted in conversation, during which the author used `dbty` / `dbty-cli` as personal shorthand for **Database Tycoon** — the company behind this project. The tool itself is the **Tycoon CLI** (the `tycoon-cli` repository, distributed on PyPI as `database-tycoon`). Any occurrence of `dbty` below refers to this same tool; it is **not** a separate product, not a fork of dbt, and not affiliated with dlt. The shorthand is preserved in places where rewriting would obscure the original framing.
+> **Naming note.** This document was originally drafted using `dbty` / `dbty-cli` as shorthand for **Database Tycoon** and the Tycoon CLI. Names are now reconciled: the tool is **tycoon** (CLI command), `src/tycoon/` (package), `tycoon.yml` (manifest), `.tycoon/` (metadata dir).
 
 > A living document. Captures the philosophy and load-bearing design ideas behind the Tycoon CLI (the `tycoon-cli` / `database-tycoon` project). This is the **why** and the **shape**, not the implementation.
 
 ---
 
-## 1. What dbty is
+## 1. What tycoon is
 
-dbty is a **stack-aware control plane** for the modern data stack — built so that humans *and* analytics agents can introspect, reason about, and act on the stack through one uniform interface.
+tycoon is a **stack-aware control plane** for the modern data stack — built so that humans *and* analytics agents can introspect, reason about, and act on the stack through one uniform interface.
 
-dbty is not an ingestion tool. dbty is not a transformation tool. dbty is not a BI tool. dbty is not a data platform. It is the layer that makes the existing tools in those categories addressable as a coherent whole.
+tycoon is not an ingestion tool. tycoon is not a transformation tool. tycoon is not a BI tool. tycoon is not a data platform. It is the layer that makes the existing tools in those categories addressable as a coherent whole.
 
 ### Control plane, not platform
 
@@ -20,7 +20,7 @@ A **platform** is a thing users live inside. It owns the runtime, the storage, t
 
 A **control plane** is a thing users (and agents) act *through*. It owns coordination, observation, and addressability. It does not own the runtimes underneath; it makes them legible and actionable as a single surface.
 
-Adjacent tools (Dango and similar) are platform-shaped. dbty deliberately is not. If we collapse into platform-shape — bundling our own warehouse, our own auth, our own everything — we look like every other tool in the category and we break the BYOS promise in §2. Holding the control-plane shape is what differentiates dbty.
+Adjacent tools (Dango and similar) are platform-shaped. tycoon deliberately is not. If we collapse into platform-shape — bundling our own warehouse, our own auth, our own everything — we look like every other tool in the category and we break the BYOS promise in §2. Holding the control-plane shape is what differentiates tycoon.
 
 Concretely:
 - A platform owns ingestion. A control plane orchestrates whoever owns ingestion.
@@ -30,37 +30,37 @@ Concretely:
 
 ## 2. The BYOS philosophy — Bring Your Own Stack
 
-The user is not asked to port, rewrite, or replatform anything to use dbty.
+The user is not asked to port, rewrite, or replatform anything to use tycoon.
 
-- If you already have ingestion in **Fivetran**, dbty leverages it.
-- If you already have ingestion in **Airbyte**, dbty leverages it.
-- If you already have a **dlt project**, dbty leverages it.
-- If you have **custom dlt sources or resources**, dbty leverages them via their entrypoint.
-- If you have **nothing yet**, dbty can run dlt natively to get you moving.
+- If you already have ingestion in **Fivetran**, tycoon leverages it.
+- If you already have ingestion in **Airbyte**, tycoon leverages it.
+- If you already have a **dlt project**, tycoon leverages it.
+- If you have **custom dlt sources or resources**, tycoon leverages them via their entrypoint.
+- If you have **nothing yet**, tycoon can run dlt natively to get you moving.
 
-dbty meets the stack where it already lives. It does not demand ownership of the ingestion runtime to be useful.
+tycoon meets the stack where it already lives. It does not demand ownership of the ingestion runtime to be useful.
 
 ## 3. The thesis: a source is an abstraction, not a runtime
 
-A **source** in dbty is an abstract object — a unified interface — not "a thing dbty runs."
+A **source** in tycoon is an abstract object — a unified interface — not "a thing tycoon runs."
 
 Every concrete source, regardless of who executes it, answers the same questions:
 
 - **Identity** — what is this, what does it represent, where does its data land?
 - **Runtime** — which engine owns execution (dlt, Fivetran, Airbyte, external dlt project, custom)?
 - **Handle** — the opaque pointer the runtime needs (a dlt pipeline, a Fivetran connector_id, an Airbyte connection_id, a path to a user's project, a Python entrypoint).
-- **Capabilities** — what can dbty actually do with this source right now? (`can_run`, `can_backfill`, `can_introspect_schema`, `can_stream_logs`, ...)
+- **Capabilities** — what can tycoon actually do with this source right now? (`can_run`, `can_backfill`, `can_introspect_schema`, `can_stream_logs`, ...)
 - **Metadata** — schema, freshness, last run, row counts, lineage. Always answerable.
 - **Data** — a uniform way to read the data once landed (warehouse-mediated).
 - **Run** — execute, *if clearance allows*. The implementation differs by materialization.
 
-`run()` is a **capability**, not a method every source must implement. Clearance — having the entrypoint or the API credentials — determines whether the capability is live for a given source. Fivetran and Airbyte are not outside dbty's reach for execution; the ingestion code simply runs elsewhere while the act of triggering and observing it lives in dbty.
+`run()` is a **capability**, not a method every source must implement. Clearance — having the entrypoint or the API credentials — determines whether the capability is live for a given source. Fivetran and Airbyte are not outside tycoon's reach for execution; the ingestion code simply runs elsewhere while the act of triggering and observing it lives in tycoon.
 
 ### The capability matrix
 
 | Concrete source | Pull data | Pull metadata | Execute `run()` |
 |---|---|---|---|
-| Native dlt source (dbty-managed) | yes | yes | yes |
+| Native dlt source (tycoon-managed) | yes | yes | yes |
 | User's custom dlt source / resource | yes | yes | yes |
 | User's existing dlt project | yes | yes | yes |
 | Fivetran connector | yes (warehouse-side) | yes (API) | yes (trigger via API) |
@@ -70,11 +70,11 @@ Same interface across all of them. Different implementations behind it. An agent
 
 ## 4. Metadata and context are load-bearing from day zero
 
-If dbty is the layer humans and agents act through, then metadata is not a downstream concern — it is the substrate.
+If tycoon is the layer humans and agents act through, then metadata is not a downstream concern — it is the substrate.
 
 This means:
 
-- **Every action a source takes** (run, backfill, schema change, error, retry) emits a structured event into a metadata store dbty owns.
+- **Every action a source takes** (run, backfill, schema change, error, retry) emits a structured event into a metadata store tycoon owns.
 - **Every read** (status, schema, freshness, lineage, capability) hits that store, or falls back to the runtime's API through a uniform adapter.
 - **Rendering for humans and agents is derived from one model.** What the CLI prints, what the TUI shows, and what the agent receives as JSON come from the same source of truth — they are not three branches.
 - **The metadata store is event-shaped, not just snapshot-shaped** — so questions like "what changed since last sync" and "what is the current state" are both answerable.
@@ -83,7 +83,7 @@ The control plane is only as useful as the context it can produce on demand.
 
 ## 5. Agent-latchability as a design constraint
 
-dbty is built so that any analytics agent can latch on and figure out how to use it without bespoke per-tool integration. The implications — to be developed further:
+tycoon is built so that any analytics agent can latch on and figure out how to use it without bespoke per-tool integration. The implications — to be developed further:
 
 - Every command is machine-introspectable; structured output is not optional.
 - The Source model is self-describing — an agent can ask "what can I do with this source?" and receive a capability list, not have to encode per-type rules.
@@ -104,12 +104,12 @@ dbty is built so that any analytics agent can latch on and figure out how to use
 - "Source type" being conflated with "source runtime" (today's catalog implicitly does this).
 - Ad-hoc, per-command output shapes that an agent has to special-case.
 - A metadata system that is bolted on after `run` rather than threaded through every action.
-- Drift toward platform-shape: bundling our own warehouse, our own auth surface, our own scheduler runtime, our own UI as the primary surface. These belong to the user's stack, not to dbty.
-- Defining our own metrics, dashboards, or semantic models. dbty does not author business definitions, dashboards, or metric DSLs. It addresses whichever Semantics and Presentation tools the user has.
+- Drift toward platform-shape: bundling our own warehouse, our own auth surface, our own scheduler runtime, our own UI as the primary surface. These belong to the user's stack, not to tycoon.
+- Defining our own metrics, dashboards, or semantic models. tycoon does not author business definitions, dashboards, or metric DSLs. It addresses whichever Semantics and Presentation tools the user has.
 
 ## 7. The compartments
 
-If dbty is a control plane, the compartments are not features — they are the **nouns the plane addresses**. Each is a distinct mental model, a distinct interface, and a distinct lifecycle. Compartmentalization is the discipline that keeps the plane legible to humans and to agents.
+If tycoon is a control plane, the compartments are not features — they are the **nouns the plane addresses**. Each is a distinct mental model, a distinct interface, and a distinct lifecycle. Compartmentalization is the discipline that keeps the plane legible to humans and to agents.
 
 There are nine compartments, plus one cross-cutting modifier. Two of them — Semantics and Presentation — are post-POC but named here because they are part of the end-to-end shape and the lineage graph cannot resolve without them.
 
@@ -133,23 +133,23 @@ Runtime as a separate compartment is what makes BYOS workable. It is also what m
 
 The warehouse or lakehouse a Source lands into. DuckDB, MotherDuck, Snowflake, BigQuery, Postgres, and so on.
 
-Sources point at Destinations. Transformations read from and write into Destinations. Critically, dbty does not *run* a Destination — it addresses one.
+Sources point at Destinations. Transformations read from and write into Destinations. Critically, tycoon does not *run* a Destination — it addresses one.
 
 ### 7.4 Transformation
 
 The user's dbt project (or projects). What models exist, what they depend on, what's stale, what just ran.
 
-Transformation is tightly coupled to Destination (a dbt run targets one). It is loosely coupled to Source (a Source's landing is a Transformation's raw input). Under BYOS, dbty does not own dbt any more than it owns Fivetran — it addresses whatever the user has.
+Transformation is tightly coupled to Destination (a dbt run targets one). It is loosely coupled to Source (a Source's landing is a Transformation's raw input). Under BYOS, tycoon does not own dbt any more than it owns Fivetran — it addresses whatever the user has.
 
 ### 7.5 Semantics (post-POC)
 
 The compartment that owns *meaning*. Metrics, dimensions, entities, joins — the business definitions of "active user," "MRR," "session." Semantics reads from a Destination (or from Transformation outputs landed in a Destination) and exposes a queryable model of what the numbers *mean*.
 
-Under BYOS, dbty does not define metrics. It addresses whichever semantic engine the user has — dbt's semantic layer (MetricFlow), Cube, Malloy, LookML, SDF semantics — through a Runtime-shaped adapter. The user's metric definitions stay where they live; dbty federates over them.
+Under BYOS, tycoon does not define metrics. It addresses whichever semantic engine the user has — dbt's semantic layer (MetricFlow), Cube, Malloy, LookML, SDF semantics — through a Runtime-shaped adapter. The user's metric definitions stay where they live; tycoon federates over them.
 
 Semantics owns: the declared metrics/dimensions/entities, the lineage from Transformation models to semantic objects, the capability to **query a metric** through the user's engine, and schema introspection for downstream Presentation tools.
 
-Semantics does *not* own: the metric definitions themselves (they live in the user's semantic project), the query engine (dbty proxies through), dashboard rendering (that is Presentation).
+Semantics does *not* own: the metric definitions themselves (they live in the user's semantic project), the query engine (tycoon proxies through), dashboard rendering (that is Presentation).
 
 POC posture: deferred. The compartment is named so the long-term shape stays honest and so the lineage graph has somewhere to resolve through. A future POC milestone may add a first adapter (likely dbt MetricFlow or Cube). The Semantics interface is a Runtime-shaped adapter contract, same shape as §7.2 — see §7.10.
 
@@ -157,7 +157,7 @@ POC posture: deferred. The compartment is named so the long-term shape stays hon
 
 The compartment that owns how landed data is *consumed* — dashboards, metrics views, reports, notebooks, embedded analytics. Presentation reads from a Destination (and, when present, from Semantics) and surfaces views the user (or an agent) interacts with.
 
-Under BYOS, dbty does not own dashboards. It addresses whichever presentation tool the user has — Rill (the POC adapter), then Metabase, Superset, Lightdash, Hex, etc. Each is a Runtime-shaped adapter.
+Under BYOS, tycoon does not own dashboards. It addresses whichever presentation tool the user has — Rill (the POC adapter), then Metabase, Superset, Lightdash, Hex, etc. Each is a Runtime-shaped adapter.
 
 Presentation owns: the declared dashboards/reports/notebooks, their dependencies on Transformation and Semantics objects, the capability to **trigger a refresh or build**, and the lineage answer for "what depends on this Source / this metric."
 
@@ -182,18 +182,18 @@ The queryable index of sources, presented uniformly across two phases of their l
 
 Same model, two phases. Browsing "what could I add" and "what's here" share a query shape so an agent uses the same call for both.
 
-Catalog is a thin compartment by design. It is a **federated query layer** over the Runtimes (for offers) and the Project (for declarations). It has no curated marketplace of its own and no store of "all the sources dbty knows about in the world" — that would be platform-shape. It federates over what's actually connected.
+Catalog is a thin compartment by design. It is a **federated query layer** over the Runtimes (for offers) and the Project (for declarations). It has no curated marketplace of its own and no store of "all the sources tycoon knows about in the world" — that would be platform-shape. It federates over what's actually connected.
 
 Two behaviors worth pinning down:
 
-- A Source the user has declared in Fivetran shows up in the Project Catalog automatically when its Runtime is attached, but with an **`unmanaged` flag** until the user explicitly claims it. dbty can read its metadata and place it in lineage; it will not trigger it. This preserves BYOS — the user already declared it in Fivetran, dbty does not require a second declaration to make it visible.
+- A Source the user has declared in Fivetran shows up in the Project Catalog automatically when its Runtime is attached, but with an **`unmanaged` flag** until the user explicitly claims it. tycoon can read its metadata and place it in lineage; it will not trigger it. This preserves BYOS — the user already declared it in Fivetran, tycoon does not require a second declaration to make it visible.
 - The Catalog API supports a **scoped mode** so the basic user's view ("offers from the Runtimes I've attached, hiding the Runtime dimension") and the agent's view ("the full federated answer") are the same API with different filters. See §10.
 
 ### 7.9 Surface
 
 The renderings of the model. CLI, JSON, TUI, web UI, MCP server for agents.
 
-No Surface is privileged. Each is a view over the same underlying model. The CLI is not the "real" dbty with everything else being decoration; the JSON is not "machine output" with the CLI being canonical. They are equal renderings, and the model — not any single Surface — is canonical.
+No Surface is privileged. Each is a view over the same underlying model. The CLI is not the "real" tycoon with everything else being decoration; the JSON is not "machine output" with the CLI being canonical. They are equal renderings, and the model — not any single Surface — is canonical.
 
 This is the architectural commitment that makes agent-latchability tractable.
 
@@ -259,21 +259,21 @@ The full §7 abstraction is the destination, not the starting point. The POC is 
 
 The POC ships exactly two Runtime adapters:
 
-- **dlt** — execution lives inside dbty's process (or a subprocess dbty controls).
-- **Fivetran** — execution lives in Fivetran; dbty triggers and observes via API.
+- **dlt** — execution lives inside tycoon's process (or a subprocess tycoon controls).
+- **Fivetran** — execution lives in Fivetran; tycoon triggers and observes via API.
 
-That pair is intentional. dlt is the only thing dbty truly *executes*; Fivetran is the canonical example of *delegated* execution. Together they exercise both ends of the capability spectrum — local-runnable and not-local-runnable — and force the Runtime interface to honestly model the difference. An abstraction designed against one example is a fiction.
+That pair is intentional. dlt is the only thing tycoon truly *executes*; Fivetran is the canonical example of *delegated* execution. Together they exercise both ends of the capability spectrum — local-runnable and not-local-runnable — and force the Runtime interface to honestly model the difference. An abstraction designed against one example is a fiction.
 
 ### Three modes
 
 From those two tools, three Source modes emerge:
 
-1. **`dlt-native`** — dbty runs a dlt source or resource. We own the shim, or the user supplied an entrypoint to their own dlt code. `run_local = yes`.
-2. **`dlt-project`** — dbty wraps a user's existing dlt project (BYOS for dlt users). dbty invokes the user's entrypoint; the project remains the user's. `run_local = yes`.
-3. **`fivetran`** — dbty observes and triggers a Fivetran connector via the Fivetran API. `run = delegated`, `run_local = no`. Schema, freshness, and lineage are pulled via the API and resolved against the user's warehouse.
+1. **`dlt-native`** — tycoon runs a dlt source or resource. We own the shim, or the user supplied an entrypoint to their own dlt code. `run_local = yes`.
+2. **`dlt-project`** — tycoon wraps a user's existing dlt project (BYOS for dlt users). tycoon invokes the user's entrypoint; the project remains the user's. `run_local = yes`.
+3. **`fivetran`** — tycoon observes and triggers a Fivetran connector via the Fivetran API. `run = delegated`, `run_local = no`. Schema, freshness, and lineage are pulled via the API and resolved against the user's warehouse.
 
 These three exercise the abstraction across the dimensions that matter:
-- runtime owned by dbty vs. owned by the user vs. owned by a third party
+- runtime owned by tycoon vs. owned by the user vs. owned by a third party
 - local-runnable vs. delegated execution
 - schema discoverable via dlt vs. via Fivetran's API vs. via warehouse introspection
 
@@ -294,7 +294,7 @@ If we can add a hypothetical `sling` Runtime later by writing one adapter and ze
 
 ### POC user experience: dlt-only by default
 
-Even though the POC builds two Runtimes, the beginner UX is **dlt-only**. Fivetran is reachable only after an explicit `dbty attach fivetran`. See §10 for the principle this enforces.
+Even though the POC builds two Runtimes, the beginner UX is **dlt-only**. Fivetran is reachable only after an explicit `tycoon attach fivetran`. See §10 for the principle this enforces.
 
 The two-Runtime architecture is what the POC *proves out*. The one-Runtime cockpit is what the beginner *sees*. These are not the same thing, and conflating them produces either a half-finished platform or a beautiful CLI that breaks the moment a second Runtime arrives.
 
@@ -304,13 +304,13 @@ The two-Runtime architecture is what the POC *proves out*. The one-Runtime cockp
 
 The goal is to give a beginner the confidence that they can fly a jet — or drive a V12 — with little to no experience. That confidence does not come from being shown the whole hangar. It comes from a small, intelligible cockpit, with the assurance that the same cockpit is the entry into the sophisticated one when they're ready.
 
-dbty's architecture is the full §7 compartments on day one. dbty's *user-facing surface area* starts much smaller and expands only through actions the user takes.
+tycoon's architecture is the full §7 compartments on day one. tycoon's *user-facing surface area* starts much smaller and expands only through actions the user takes.
 
 ### The three altitudes
 
-- **Day one — beginner, no inventory.** `dbty attach` (or `dbty init` as an alias) in an empty project. dbty picks the Runtime: dlt-native. dbty picks the Destination: local DuckDB. The Catalog the user browses is just dlt's verified sources plus REST API and Filesystem as escape hatches. The user never sees the word *Runtime*. They see *sources*. They pick one, it works.
-- **Day thirty — intermediate, has existing things.** The user attaches a second Runtime: `dbty attach dlt-project ./path` to wrap an existing project. The Catalog becomes a union. The Runtime column shows up in `dbty source list` for the first time, because now there is something to distinguish. One more dial revealed. Not the whole panel.
-- **Day ninety — sophisticated, multi-Runtime.** `dbty attach fivetran` pulls in their workspace. The Catalog is now a federated view across three Runtimes. Fivetran connectors show up auto-discovered, marked `unmanaged`, until the user claims them. The full cockpit is visible — and earned, because the user encountered each compartment as it became necessary.
+- **Day one — beginner, no inventory.** `tycoon attach` (or `tycoon init` as an alias) in an empty project. tycoon picks the Runtime: dlt-native. tycoon picks the Destination: local DuckDB. The Catalog the user browses is just dlt's verified sources plus REST API and Filesystem as escape hatches. The user never sees the word *Runtime*. They see *sources*. They pick one, it works.
+- **Day thirty — intermediate, has existing things.** The user attaches a second Runtime: `tycoon attach dlt-project ./path` to wrap an existing project. The Catalog becomes a union. The Runtime column shows up in `tycoon source list` for the first time, because now there is something to distinguish. One more dial revealed. Not the whole panel.
+- **Day ninety — sophisticated, multi-Runtime.** `tycoon attach fivetran` pulls in their workspace. The Catalog is now a federated view across three Runtimes. Fivetran connectors show up auto-discovered, marked `unmanaged`, until the user claims them. The full cockpit is visible — and earned, because the user encountered each compartment as it became necessary.
 
 ### What this commits the architecture to
 
@@ -318,7 +318,7 @@ Progressive disclosure is a UX promise. It only holds if three things are true u
 
 1. **Defaults are first-class.** A Runtime can be a default. A Destination can be a default. Code paths cleanly resolve "if no Runtime is named, use dlt-native; if no Destination is named, use the project's local DuckDB." Defaults are not fallbacks bolted onto error paths — they are a feature of the Project that the basic user benefits from invisibly.
 2. **The Catalog API supports a scoped mode.** The same federated query layer answers two questions with a filter parameter: "offers from the Runtimes I've attached, hiding the Runtime dimension" (the beginner's view) and "the full federated answer" (the agent's view). One API, not two.
-3. **Commands degrade gracefully.** `dbty source add github` works for the beginner without them naming a Runtime, because there is exactly one attached and it can offer github. The same command in a multi-Runtime project disambiguates by asking. The control plane *infers* when it can, and *asks* when it can't. It never *requires* the user to name a dimension they don't yet know exists.
+3. **Commands degrade gracefully.** `tycoon source add github` works for the beginner without them naming a Runtime, because there is exactly one attached and it can offer github. The same command in a multi-Runtime project disambiguates by asking. The control plane *infers* when it can, and *asks* when it can't. It never *requires* the user to name a dimension they don't yet know exists.
 
 ### The non-negotiables
 
@@ -330,16 +330,16 @@ If a feature breaks any of these three, it is wrong even if it works.
 
 ### `attach`, not `init`
 
-Under this principle, `attach` is the dominant verb of the control plane. `init` is an alias for the greenfield case where attaching means binding to defaults. The distinction matters because *init* implies dbty *creates*; *attach* implies dbty *connects*. A control plane connects.
+Under this principle, `attach` is the dominant verb of the control plane. `init` is an alias for the greenfield case where attaching means binding to defaults. The distinction matters because *init* implies tycoon *creates*; *attach* implies tycoon *connects*. A control plane connects.
 
 ### Scaffolding: the silent first move
 
-When `attach` is invoked against a greenfield directory — or against a Runtime / Transformation / Presentation that the user has not yet set up — `attach` scaffolds the minimum required state silently, then performs the attach. The user types `dbty attach` once; the scaffold happens invisibly underneath. There is no `dbty scaffold` verb. The beginner never learns the word.
+When `attach` is invoked against a greenfield directory — or against a Runtime / Transformation / Presentation that the user has not yet set up — `attach` scaffolds the minimum required state silently, then performs the attach. The user types `tycoon attach` once; the scaffold happens invisibly underneath. There is no `tycoon scaffold` verb. The beginner never learns the word.
 
 Scaffolding operates under a strict charter:
 
 1. **Minimum only.** A scaffolder writes only what is strictly needed for the next user action to succeed. Nothing aspirational. Nothing "best-practices." Nothing the user did not ask for.
-2. **In the user's idiom.** If the scaffolder is for dbt, it writes dbt-shaped files. If it is for Rill, it writes Rill-shaped files. dbty does not wrap them in a dbty-shaped envelope. The user gets a project their tool of choice recognises natively.
+2. **In the user's idiom.** If the scaffolder is for dbt, it writes dbt-shaped files. If it is for Rill, it writes Rill-shaped files. tycoon does not wrap them in a tycoon-shaped envelope. The user gets a project their tool of choice recognises natively.
 3. **Strictly create-only.** A scaffolder writes new files in empty space. It never edits, appends to, or merges into the user's existing files. If the relevant artifacts already exist, `attach` discovers and binds to them instead of scaffolding — the scaffold step is skipped, not partially run.
 4. **Once.** Re-running `attach` does not re-scaffold. Scaffolding is one-shot, greenfield-only. Subsequent attaches *attach*; they do not mutate.
 

--- a/docs/proposals/_tycoon/MANIFESTO.md
+++ b/docs/proposals/_tycoon/MANIFESTO.md
@@ -1,0 +1,365 @@
+# Tycoon CLI Manifesto
+
+> **Naming note.** This document was drafted in conversation, during which the author used `dbty` / `dbty-cli` as personal shorthand for **Database Tycoon** — the company behind this project. The tool itself is the **Tycoon CLI** (the `tycoon-cli` repository, distributed on PyPI as `database-tycoon`). Any occurrence of `dbty` below refers to this same tool; it is **not** a separate product, not a fork of dbt, and not affiliated with dlt. The shorthand is preserved in places where rewriting would obscure the original framing.
+
+> A living document. Captures the philosophy and load-bearing design ideas behind the Tycoon CLI (the `tycoon-cli` / `database-tycoon` project). This is the **why** and the **shape**, not the implementation.
+
+---
+
+## 1. What dbty is
+
+dbty is a **stack-aware control plane** for the modern data stack — built so that humans *and* analytics agents can introspect, reason about, and act on the stack through one uniform interface.
+
+dbty is not an ingestion tool. dbty is not a transformation tool. dbty is not a BI tool. dbty is not a data platform. It is the layer that makes the existing tools in those categories addressable as a coherent whole.
+
+### Control plane, not platform
+
+The distinction is load-bearing, not cosmetic.
+
+A **platform** is a thing users live inside. It owns the runtime, the storage, the auth, the scheduler, the UI. It absorbs the user's stack. To get value out of a platform you replatform onto it.
+
+A **control plane** is a thing users (and agents) act *through*. It owns coordination, observation, and addressability. It does not own the runtimes underneath; it makes them legible and actionable as a single surface.
+
+Adjacent tools (Dango and similar) are platform-shaped. dbty deliberately is not. If we collapse into platform-shape — bundling our own warehouse, our own auth, our own everything — we look like every other tool in the category and we break the BYOS promise in §2. Holding the control-plane shape is what differentiates dbty.
+
+Concretely:
+- A platform owns ingestion. A control plane orchestrates whoever owns ingestion.
+- A platform stores the data. A control plane reads from wherever the data lives.
+- A platform forces a UI. A control plane treats every surface (CLI, TUI, JSON, agent) as an equally valid rendering of the same model.
+- A platform's strength is bundled features. A control plane's strength is uniform addressability.
+
+## 2. The BYOS philosophy — Bring Your Own Stack
+
+The user is not asked to port, rewrite, or replatform anything to use dbty.
+
+- If you already have ingestion in **Fivetran**, dbty leverages it.
+- If you already have ingestion in **Airbyte**, dbty leverages it.
+- If you already have a **dlt project**, dbty leverages it.
+- If you have **custom dlt sources or resources**, dbty leverages them via their entrypoint.
+- If you have **nothing yet**, dbty can run dlt natively to get you moving.
+
+dbty meets the stack where it already lives. It does not demand ownership of the ingestion runtime to be useful.
+
+## 3. The thesis: a source is an abstraction, not a runtime
+
+A **source** in dbty is an abstract object — a unified interface — not "a thing dbty runs."
+
+Every concrete source, regardless of who executes it, answers the same questions:
+
+- **Identity** — what is this, what does it represent, where does its data land?
+- **Runtime** — which engine owns execution (dlt, Fivetran, Airbyte, external dlt project, custom)?
+- **Handle** — the opaque pointer the runtime needs (a dlt pipeline, a Fivetran connector_id, an Airbyte connection_id, a path to a user's project, a Python entrypoint).
+- **Capabilities** — what can dbty actually do with this source right now? (`can_run`, `can_backfill`, `can_introspect_schema`, `can_stream_logs`, ...)
+- **Metadata** — schema, freshness, last run, row counts, lineage. Always answerable.
+- **Data** — a uniform way to read the data once landed (warehouse-mediated).
+- **Run** — execute, *if clearance allows*. The implementation differs by materialization.
+
+`run()` is a **capability**, not a method every source must implement. Clearance — having the entrypoint or the API credentials — determines whether the capability is live for a given source. Fivetran and Airbyte are not outside dbty's reach for execution; the ingestion code simply runs elsewhere while the act of triggering and observing it lives in dbty.
+
+### The capability matrix
+
+| Concrete source | Pull data | Pull metadata | Execute `run()` |
+|---|---|---|---|
+| Native dlt source (dbty-managed) | yes | yes | yes |
+| User's custom dlt source / resource | yes | yes | yes |
+| User's existing dlt project | yes | yes | yes |
+| Fivetran connector | yes (warehouse-side) | yes (API) | yes (trigger via API) |
+| Airbyte connection | yes (warehouse-side) | yes (API) | yes (trigger via API) |
+
+Same interface across all of them. Different implementations behind it. An agent asks the same questions and gets typed answers regardless of which row it's looking at.
+
+## 4. Metadata and context are load-bearing from day zero
+
+If dbty is the layer humans and agents act through, then metadata is not a downstream concern — it is the substrate.
+
+This means:
+
+- **Every action a source takes** (run, backfill, schema change, error, retry) emits a structured event into a metadata store dbty owns.
+- **Every read** (status, schema, freshness, lineage, capability) hits that store, or falls back to the runtime's API through a uniform adapter.
+- **Rendering for humans and agents is derived from one model.** What the CLI prints, what the TUI shows, and what the agent receives as JSON come from the same source of truth — they are not three branches.
+- **The metadata store is event-shaped, not just snapshot-shaped** — so questions like "what changed since last sync" and "what is the current state" are both answerable.
+
+The control plane is only as useful as the context it can produce on demand.
+
+## 5. Agent-latchability as a design constraint
+
+dbty is built so that any analytics agent can latch on and figure out how to use it without bespoke per-tool integration. The implications — to be developed further:
+
+- Every command is machine-introspectable; structured output is not optional.
+- The Source model is self-describing — an agent can ask "what can I do with this source?" and receive a capability list, not have to encode per-type rules.
+- The CLI is a typed API surface. The human UX is a thin rendering layer on top of it.
+
+(Section 5 is an anchor — the full shape of agent-latchability is a conversation still in progress.)
+
+## 6. What this rules in, and what it rules out
+
+**In:**
+- A unified `Source` abstraction with pluggable runtime adapters.
+- A first-class metadata substrate that captures events, schemas, and lineage.
+- Read paths and write paths through the same interface, regardless of who runs the ingest.
+- Native dlt as one runtime among several — neither privileged nor required.
+
+**Out:**
+- Forcing users to port from Fivetran/Airbyte/their own dlt setup.
+- "Source type" being conflated with "source runtime" (today's catalog implicitly does this).
+- Ad-hoc, per-command output shapes that an agent has to special-case.
+- A metadata system that is bolted on after `run` rather than threaded through every action.
+- Drift toward platform-shape: bundling our own warehouse, our own auth surface, our own scheduler runtime, our own UI as the primary surface. These belong to the user's stack, not to dbty.
+- Defining our own metrics, dashboards, or semantic models. dbty does not author business definitions, dashboards, or metric DSLs. It addresses whichever Semantics and Presentation tools the user has.
+
+## 7. The compartments
+
+If dbty is a control plane, the compartments are not features — they are the **nouns the plane addresses**. Each is a distinct mental model, a distinct interface, and a distinct lifecycle. Compartmentalization is the discipline that keeps the plane legible to humans and to agents.
+
+There are nine compartments, plus one cross-cutting modifier. Two of them — Semantics and Presentation — are post-POC but named here because they are part of the end-to-end shape and the lineage graph cannot resolve without them.
+
+### 7.1 Source
+
+A declared lineage anchor. "Data from system X lands at warehouse location Y, owned by runtime Z." A Source owns its **identity**, its **runtime binding**, its **handle**, its **capabilities**, and its observed **schema** and **freshness**.
+
+A Source does *not* own the warehouse, the transformations, or the dashboards. It is a node in a graph, not a system.
+
+### 7.2 Runtime
+
+The execution backend behind a Source. A Runtime is an adapter that implements the capability set on behalf of whatever's actually doing the work.
+
+A Source has exactly one Runtime. A Runtime can back many Sources.
+
+The POC ships two Runtimes and three modes — see §8.
+
+Runtime as a separate compartment is what makes BYOS workable. It is also what makes environments-as-rebinding (§7.7) possible.
+
+### 7.3 Destination
+
+The warehouse or lakehouse a Source lands into. DuckDB, MotherDuck, Snowflake, BigQuery, Postgres, and so on.
+
+Sources point at Destinations. Transformations read from and write into Destinations. Critically, dbty does not *run* a Destination — it addresses one.
+
+### 7.4 Transformation
+
+The user's dbt project (or projects). What models exist, what they depend on, what's stale, what just ran.
+
+Transformation is tightly coupled to Destination (a dbt run targets one). It is loosely coupled to Source (a Source's landing is a Transformation's raw input). Under BYOS, dbty does not own dbt any more than it owns Fivetran — it addresses whatever the user has.
+
+### 7.5 Semantics (post-POC)
+
+The compartment that owns *meaning*. Metrics, dimensions, entities, joins — the business definitions of "active user," "MRR," "session." Semantics reads from a Destination (or from Transformation outputs landed in a Destination) and exposes a queryable model of what the numbers *mean*.
+
+Under BYOS, dbty does not define metrics. It addresses whichever semantic engine the user has — dbt's semantic layer (MetricFlow), Cube, Malloy, LookML, SDF semantics — through a Runtime-shaped adapter. The user's metric definitions stay where they live; dbty federates over them.
+
+Semantics owns: the declared metrics/dimensions/entities, the lineage from Transformation models to semantic objects, the capability to **query a metric** through the user's engine, and schema introspection for downstream Presentation tools.
+
+Semantics does *not* own: the metric definitions themselves (they live in the user's semantic project), the query engine (dbty proxies through), dashboard rendering (that is Presentation).
+
+POC posture: deferred. The compartment is named so the long-term shape stays honest and so the lineage graph has somewhere to resolve through. A future POC milestone may add a first adapter (likely dbt MetricFlow or Cube). The Semantics interface is a Runtime-shaped adapter contract, same shape as §7.2 — see §7.10.
+
+### 7.6 Presentation (post-POC for non-CLI surfaces; POC includes the warehouse-anchored read path)
+
+The compartment that owns how landed data is *consumed* — dashboards, metrics views, reports, notebooks, embedded analytics. Presentation reads from a Destination (and, when present, from Semantics) and surfaces views the user (or an agent) interacts with.
+
+Under BYOS, dbty does not own dashboards. It addresses whichever presentation tool the user has — Rill (the POC adapter), then Metabase, Superset, Lightdash, Hex, etc. Each is a Runtime-shaped adapter.
+
+Presentation owns: the declared dashboards/reports/notebooks, their dependencies on Transformation and Semantics objects, the capability to **trigger a refresh or build**, and the lineage answer for "what depends on this Source / this metric."
+
+Presentation does *not* own: the dashboard rendering itself (the user's tool does that), the metric definitions (those are Semantics), the warehouse data (that is Destination).
+
+POC posture: a thin first adapter for Rill is in scope as the canonical example. The compartment is named alongside Transformation because they are structurally symmetric — both read from a Destination, both have a user-owned project, both have a `run`/`refresh`-shaped verb, both need pluggable runtimes. Separating them is the choice that keeps "produces warehouse state" and "consumes warehouse state" from collapsing into a single hand-wavy concept.
+
+### 7.7 Metadata
+
+The substrate every other compartment writes to and reads from. Event-shaped, not just snapshot-shaped.
+
+Every action — a sync ran, a schema drifted, a model failed, a backfill was requested — flows through Metadata. Every read — current schema, last freshness, lineage from this Source to that dashboard — resolves through Metadata.
+
+Metadata is not a feature users add to. It is the connective tissue that makes the other compartments legible. It is the substrate the agent thinks through.
+
+### 7.8 Catalog
+
+The queryable index of sources, presented uniformly across two phases of their lifecycle:
+
+- **Runtime Catalog** — what each attached Runtime *offers*. The dlt verified-sources registry. The user's available Fivetran connectors. The resources discoverable inside the user's dlt project. Answered by asking each Runtime.
+- **Project Catalog** — what this project has *declared*. The union of all configured Sources, each carrying its Runtime binding.
+
+Same model, two phases. Browsing "what could I add" and "what's here" share a query shape so an agent uses the same call for both.
+
+Catalog is a thin compartment by design. It is a **federated query layer** over the Runtimes (for offers) and the Project (for declarations). It has no curated marketplace of its own and no store of "all the sources dbty knows about in the world" — that would be platform-shape. It federates over what's actually connected.
+
+Two behaviors worth pinning down:
+
+- A Source the user has declared in Fivetran shows up in the Project Catalog automatically when its Runtime is attached, but with an **`unmanaged` flag** until the user explicitly claims it. dbty can read its metadata and place it in lineage; it will not trigger it. This preserves BYOS — the user already declared it in Fivetran, dbty does not require a second declaration to make it visible.
+- The Catalog API supports a **scoped mode** so the basic user's view ("offers from the Runtimes I've attached, hiding the Runtime dimension") and the agent's view ("the full federated answer") are the same API with different filters. See §10.
+
+### 7.9 Surface
+
+The renderings of the model. CLI, JSON, TUI, web UI, MCP server for agents.
+
+No Surface is privileged. Each is a view over the same underlying model. The CLI is not the "real" dbty with everything else being decoration; the JSON is not "machine output" with the CLI being canonical. They are equal renderings, and the model — not any single Surface — is canonical.
+
+This is the architectural commitment that makes agent-latchability tractable.
+
+### 7.10 Environment (cross-cutting)
+
+Environment is not a compartment. It is a **modifier** that lives across Source and Destination, and it answers a single question:
+
+> When I am running in *this* environment, which Runtime does each Source resolve to, and which Destination am I pointed at?
+
+The same `stripe_payments` Source can be bound to a Fivetran Runtime in `prod` and to a `dlt-native` Runtime (pulling a fixture or sampled subset) in `dev`. The Source's identity, its downstream consumers, and its place in the lineage graph do not change. Only the binding does.
+
+Without this, mixed-runtime stacks force users to declare every Source twice and keep them manually in sync. With it, environments become a binding concern instead of a duplication concern — and the lineage graph stays whole across local dev, CI, and production.
+
+### Map
+
+```
+   ┌─────────────────────────────────────────────────────┐
+   │     Surfaces   (CLI / JSON / TUI / Web / MCP)       │
+   └─────────────────────────────────────────────────────┘
+                           │
+   ┌─────────────────────────────────────────────────────┐
+   │                Metadata substrate                   │
+   │       (events, schemas, lineage, capabilities)      │
+   └─────────────────────────────────────────────────────┘
+        │                  │                  │             │              │
+   ┌────────┐        ┌─────────────┐    ┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+   │ Source │──────▶│ Destination │◀──│Transformation│  │  Semantics   │  │ Presentation │
+   └────────┘        └─────────────┘    └──────────────┘  │ (post-POC)   │  │ (Rill = POC) │
+        │ ▲              ▲   ▲                            └──────┬───────┘  └──────┬───────┘
+        │ │              │   │                                   │                 │
+        │ │              │   └───────────────────────────────────┘                 │
+        │ │              └─────────────────────────────────────────────────────────┘
+        │ │      ┌──────────────────────────────────────┐
+        │ └──────│ Catalog  (federated query layer:     │
+        │        │   Runtime offers + Project declared) │
+        │        └──────────────────────────────────────┘
+   ┌─────────┐
+   │ Runtime │   dlt-native | dlt-project | fivetran | (sling, airbyte, ...)
+   └─────────┘     for Source, Transformation, Semantics, Presentation alike
+
+        ▲
+        │
+   Environment rebinds Source→Runtime and selects Destination per profile.
+```
+
+End-to-end, the lineage flows: **Source → Destination ← Transformation → (Destination ← Semantics) → Presentation.** The control plane addresses every link without owning any of them.
+
+### Open compartmentalization questions
+
+These are intentionally unresolved and named here so they don't get silently re-decided:
+
+1. **Destination — first-class or property of Environment?** It is first-class here because Transformation needs to address it independently and most users have multiple (dev DuckDB + prod Snowflake). The Environment view is plausible; revisit if it causes friction.
+2. **Transformation as a single compartment vs. a Runtime-shaped thing.** Today it is one compartment, but BYOS suggests Transformation may itself need pluggable runtimes (dbt-local, dbt-cloud, sqlmesh) at some point. Defer until we have a second example.
+3. **Where ad-hoc Operations live.** Trigger a backfill, request a schema diff, ask an agent to draft a model — these cross compartments. Currently treated as verbs on Source/Transformation rather than their own compartment. Revisit if the cross-cutting surface gets noisy.
+
+---
+
+## 8. POC scope: two tools, three modes
+
+The full §7 abstraction is the destination, not the starting point. The POC is deliberately narrow so the seams it forces into existence are real, not hypothetical.
+
+### Two tools
+
+The POC ships exactly two Runtime adapters:
+
+- **dlt** — execution lives inside dbty's process (or a subprocess dbty controls).
+- **Fivetran** — execution lives in Fivetran; dbty triggers and observes via API.
+
+That pair is intentional. dlt is the only thing dbty truly *executes*; Fivetran is the canonical example of *delegated* execution. Together they exercise both ends of the capability spectrum — local-runnable and not-local-runnable — and force the Runtime interface to honestly model the difference. An abstraction designed against one example is a fiction.
+
+### Three modes
+
+From those two tools, three Source modes emerge:
+
+1. **`dlt-native`** — dbty runs a dlt source or resource. We own the shim, or the user supplied an entrypoint to their own dlt code. `run_local = yes`.
+2. **`dlt-project`** — dbty wraps a user's existing dlt project (BYOS for dlt users). dbty invokes the user's entrypoint; the project remains the user's. `run_local = yes`.
+3. **`fivetran`** — dbty observes and triggers a Fivetran connector via the Fivetran API. `run = delegated`, `run_local = no`. Schema, freshness, and lineage are pulled via the API and resolved against the user's warehouse.
+
+These three exercise the abstraction across the dimensions that matter:
+- runtime owned by dbty vs. owned by the user vs. owned by a third party
+- local-runnable vs. delegated execution
+- schema discoverable via dlt vs. via Fivetran's API vs. via warehouse introspection
+
+### Out of scope for the POC
+
+Sling, Airbyte (cloud and OSS), custom-entrypoint Runtimes beyond dlt, dbt-cloud as a Transformation runtime, MCP surface, web Surface. All deliberately deferred — but the Runtime interface designed for the POC must be the same interface those future adapters slot into. No private door for sling/Airbyte to use later that the POC adapters didn't.
+
+### Design discipline for the POC
+
+The POC's only architectural job, beyond working, is to **produce a Runtime interface that future adapters can implement without modification to the core**. Concretely:
+
+- The capability model is declared on the Runtime, not hardcoded in commands.
+- Every Surface (CLI, JSON for agents) reads the same model and does not branch on Runtime.
+- Metadata events are runtime-shaped uniformly — a Fivetran sync completion and a dlt run completion are the same event with different payloads, not two different code paths.
+- No Runtime gets a special case in the core. If Fivetran needs something, it needs it through the interface, and dlt-native gets the same hook.
+
+If we can add a hypothetical `sling` Runtime later by writing one adapter and zero core changes, the POC succeeded. If we can't, the POC's interface is wrong and we fix it before more Runtimes pile on.
+
+### POC user experience: dlt-only by default
+
+Even though the POC builds two Runtimes, the beginner UX is **dlt-only**. Fivetran is reachable only after an explicit `dbty attach fivetran`. See §10 for the principle this enforces.
+
+The two-Runtime architecture is what the POC *proves out*. The one-Runtime cockpit is what the beginner *sees*. These are not the same thing, and conflating them produces either a half-finished platform or a beautiful CLI that breaks the moment a second Runtime arrives.
+
+---
+
+## 9. Progressive disclosure: the cockpit, not the hangar
+
+The goal is to give a beginner the confidence that they can fly a jet — or drive a V12 — with little to no experience. That confidence does not come from being shown the whole hangar. It comes from a small, intelligible cockpit, with the assurance that the same cockpit is the entry into the sophisticated one when they're ready.
+
+dbty's architecture is the full §7 compartments on day one. dbty's *user-facing surface area* starts much smaller and expands only through actions the user takes.
+
+### The three altitudes
+
+- **Day one — beginner, no inventory.** `dbty attach` (or `dbty init` as an alias) in an empty project. dbty picks the Runtime: dlt-native. dbty picks the Destination: local DuckDB. The Catalog the user browses is just dlt's verified sources plus REST API and Filesystem as escape hatches. The user never sees the word *Runtime*. They see *sources*. They pick one, it works.
+- **Day thirty — intermediate, has existing things.** The user attaches a second Runtime: `dbty attach dlt-project ./path` to wrap an existing project. The Catalog becomes a union. The Runtime column shows up in `dbty source list` for the first time, because now there is something to distinguish. One more dial revealed. Not the whole panel.
+- **Day ninety — sophisticated, multi-Runtime.** `dbty attach fivetran` pulls in their workspace. The Catalog is now a federated view across three Runtimes. Fivetran connectors show up auto-discovered, marked `unmanaged`, until the user claims them. The full cockpit is visible — and earned, because the user encountered each compartment as it became necessary.
+
+### What this commits the architecture to
+
+Progressive disclosure is a UX promise. It only holds if three things are true under the surface:
+
+1. **Defaults are first-class.** A Runtime can be a default. A Destination can be a default. Code paths cleanly resolve "if no Runtime is named, use dlt-native; if no Destination is named, use the project's local DuckDB." Defaults are not fallbacks bolted onto error paths — they are a feature of the Project that the basic user benefits from invisibly.
+2. **The Catalog API supports a scoped mode.** The same federated query layer answers two questions with a filter parameter: "offers from the Runtimes I've attached, hiding the Runtime dimension" (the beginner's view) and "the full federated answer" (the agent's view). One API, not two.
+3. **Commands degrade gracefully.** `dbty source add github` works for the beginner without them naming a Runtime, because there is exactly one attached and it can offer github. The same command in a multi-Runtime project disambiguates by asking. The control plane *infers* when it can, and *asks* when it can't. It never *requires* the user to name a dimension they don't yet know exists.
+
+### The non-negotiables
+
+- The basic user never has to learn the word *Runtime*.
+- The sophisticated user never feels constrained by the basic user's affordances.
+- The model is canonical; what the user sees is a rendering of it.
+
+If a feature breaks any of these three, it is wrong even if it works.
+
+### `attach`, not `init`
+
+Under this principle, `attach` is the dominant verb of the control plane. `init` is an alias for the greenfield case where attaching means binding to defaults. The distinction matters because *init* implies dbty *creates*; *attach* implies dbty *connects*. A control plane connects.
+
+### Scaffolding: the silent first move
+
+When `attach` is invoked against a greenfield directory — or against a Runtime / Transformation / Presentation that the user has not yet set up — `attach` scaffolds the minimum required state silently, then performs the attach. The user types `dbty attach` once; the scaffold happens invisibly underneath. There is no `dbty scaffold` verb. The beginner never learns the word.
+
+Scaffolding operates under a strict charter:
+
+1. **Minimum only.** A scaffolder writes only what is strictly needed for the next user action to succeed. Nothing aspirational. Nothing "best-practices." Nothing the user did not ask for.
+2. **In the user's idiom.** If the scaffolder is for dbt, it writes dbt-shaped files. If it is for Rill, it writes Rill-shaped files. dbty does not wrap them in a dbty-shaped envelope. The user gets a project their tool of choice recognises natively.
+3. **Strictly create-only.** A scaffolder writes new files in empty space. It never edits, appends to, or merges into the user's existing files. If the relevant artifacts already exist, `attach` discovers and binds to them instead of scaffolding — the scaffold step is skipped, not partially run.
+4. **Once.** Re-running `attach` does not re-scaffold. Scaffolding is one-shot, greenfield-only. Subsequent attaches *attach*; they do not mutate.
+
+These rules are what keep scaffolding from drifting into config-management, which is the failure mode where scaffolding tools become platforms.
+
+---
+
+## 10. Status of this document
+
+This manifesto reflects the design conversation as of 2026-06-18. The control-plane framing is aligned with founders' direction (a LinkedIn announcement co-authored by Karl and Jason names this positioning publicly). It is the starting point for:
+
+1. An inventory and diagnosis pass on the current `tycoon-cli` codebase against this thesis.
+2. A design proposal for the Source / Runtime / Catalog / Metadata interfaces.
+3. An in-flight migration plan — changing the engine while the plane keeps flying.
+
+Open threads to develop further:
+- The full shape of agent-latchability (Section 5).
+- How `run()` clearance is modeled, declared, and revoked.
+- The metadata event schema and the read/write API over it.
+- Whether the command surface beyond sources also needs to be agent-shaped, or just the source surface for now.
+- The exact shape of the Catalog scoped-mode filter and how the unmanaged-flag transition (claim/unclaim) is modeled.
+- Presentation adapter shape — confirmed structurally symmetric to Transformation; Rill is the POC adapter.
+- Semantics adapter shape and timing — when the first semantic-engine adapter (likely dbt MetricFlow or Cube) lands, and whether a "semantic API as a Surface" rendering (a unified `/metric?name=...` endpoint federated over the user's engine) earns its place on the roadmap.

--- a/docs/proposals/_tycoon/PLAN.md
+++ b/docs/proposals/_tycoon/PLAN.md
@@ -1,0 +1,262 @@
+# PLAN — Tycoon CLI Rewrite
+
+> Companion to [MANIFESTO.md](./MANIFESTO.md) (the *why*) and [ARCHITECTURE.md](./ARCHITECTURE.md) (the *how it's built*). This document is the *what we're doing about it* — the execution plan to evolve the current codebase toward the new vision.
+>
+> Intended audience: contributors and reviewers (Stephen, the team). Will be threaded as a GitHub issue once vetted internally.
+
+---
+
+## TL;DR
+
+We are rewriting the ingestion layer of `tycoon-cli` against the abstractions in MANIFESTO.md and ARCHITECTURE.md. Two existing packages will coexist in this repo during the rewrite: `src/tycoon/` (current production code, entrypoint `tycoon`) and `src/_tycoon/` (the rewrite, entrypoint `tycli`). When the rewrite reaches feature parity for ingestion and passes the architectural acceptance test (Fivetran adapter slotted in with zero core changes), we cut over in a single PR: delete `src/tycoon/`, rename `src/_tycoon/` → `src/tycoon/`. The `tycli` entrypoint stays as either an alias or the primary command depending on what we've learned by then.
+
+The decision to rewrite rather than refactor was made after a focused inventory pass (Appendix A). The current code is ~50% reshapeable, ~30% actively contradicts the new shape, and the load-bearing assumptions (source-type conflated with runtime, dispatch hardcoded to dlt, shims monolithic) are exactly the assumptions the new abstractions exist to remove. Refactoring in-place would force a months-long half-converted state. Rewriting in parallel keeps the production CLI working while the new shape is built deliberately.
+
+---
+
+## Decisions locked
+
+These are settled. Each is recorded here so the rationale is durable.
+
+### D1 — Rewrite path: extract a new package, port the good parts
+
+Build a new package at `src/_tycoon/` from scratch against the manifesto and architecture. The old `src/tycoon/` remains untouched in the same repo as a working fallback. Four specific patterns from the old code will be ported deliberately (see §"Port list"). Everything else either gets rebuilt with the right shape or stays out.
+
+**Why not refactor in place:** half-converted codebases die of contortion. Every PR becomes "rename this, gate that, add a flag." The load-bearing assumptions in the current code are exactly what the new abstractions remove — fighting them in-flight is slower than rebuilding cleanly.
+
+**Why not pure greenfield in a separate repo:** we'd lose the four patterns worth porting, lose the git history, and create a coordination problem (two repos to track, two PyPI distributions to reconcile). Same-repo coexistence is cheaper.
+
+**Why the install-base does not constrain:** ~17 PyPI downloads/day, no known production users. The team is the entire user base. No coexistence-for-users requirement.
+
+### D2 — Package and entrypoint naming
+
+| Surface | During rewrite window | At cutover |
+|---|---|---|
+| Import path | `_tycoon` | `tycoon` |
+| Filesystem | `src/_tycoon/` | `src/tycoon/` (old deleted) |
+| Entrypoint command | `tycli` | `tycli` (alias) and/or `tycoon` (decide at cutover) |
+| PyPI distribution | unchanged (`database-tycoon`) | unchanged unless we rename deliberately |
+
+The leading underscore is the explicit "in-progress, will-be-renamed" marker. It cannot be invoked by accident through `tycoon`. The entrypoint is decoupled from the import name from day one — that decoupling is permanent, not just a rewrite-window convenience. We never again confuse "what the package is called internally" with "what the user types."
+
+### D3 — CLI as a thin shell over a programmatic API
+
+Every command returns a typed result. The CLI renderer formats it for humans; the JSON surface emits the same model unchanged for agents; future surfaces (MCP, TUI) read the same model. The Python API is the real product; the CLI imports and calls it.
+
+**What this means concretely:**
+- No command function "prints a table." It returns a structured result object; a renderer prints the table.
+- `--json` works on every command by default, emitting the same model the CLI rendered.
+- `from _tycoon import sources; sources.add(...)` gives an experience equivalent to `tycli source add ...`.
+- This is the manifesto §5 (agent-latchability) commitment made concrete from day one. Retrofitting later is much harder than building toward it.
+
+### D4 — Quality scaffolding from day one, proportionate
+
+| Concern | Decision |
+|---|---|
+| Test framework | pytest (same as current `tycoon`) |
+| Test types | Unit tests for `core/`; integration tests for adapters; one end-to-end test for the Phase 1 vertical slice |
+| Coverage target | None as a number. Behavioral floor: each `core/` module has tests; each adapter has at least one integration test; each command has a smoke test |
+| Linting | ruff (strict-ish — fail on import order, unused, undocumented public APIs in `core/`) |
+| Type checking | mypy or pyright in strict mode on `core/`; looser on adapters where third-party stubs are weak |
+| CI | One GitHub Actions workflow: lint + type-check + test on PRs |
+| Pre-commit hooks | ruff format + ruff check + mypy on changed files |
+| `CLAUDE.md` | At `src/_tycoon/` root. Short (under 200 lines). Covers manifesto's load-bearing rules, layering constraints, "where new things go," test/lint expectations |
+
+Done first, before any business logic. Empty package, working CI, working pre-commit, empty `CLAUDE.md`. Sets the tone.
+
+### D5 — POC scope: ingestion only, two Runtimes, three modes
+
+Per manifesto §8. The rewrite ships exactly two Runtime adapters in the POC:
+
+- **dlt** — execution in-process (or in a controlled subprocess for `dlt-project`)
+- **Fivetran** — execution delegated; dbty observes and triggers via API
+
+From those, three Source modes:
+
+1. **`dlt-native`** — dbty runs a dlt source or resource (own shim or user entrypoint)
+2. **`dlt-project`** — dbty wraps a user's existing dlt project
+3. **`fivetran`** — dbty observes and triggers a Fivetran connector via API
+
+**Out of scope for this rewrite:** Transformation, Semantics, Presentation, additional Surfaces (MCP, TUI, web). The architecture has homes for these; they are built after Phase 2 lands.
+
+---
+
+## Sequencing
+
+Four steps, in order. Each has a concrete acceptance criterion. No step starts until the previous one passes.
+
+### Step 1 — Rails up
+
+**Goal:** Empty package with all quality scaffolding working. No business logic.
+
+**Concrete deliverables:**
+- `src/_tycoon/` directory with the layout from ARCHITECTURE.md §"Level 4 — Code" (`core/`, `runtimes/`, `destinations/`, `metadata_backends/`, `scaffolds/`, `surfaces/cli/`, `surfaces/json/`).
+- Every module is empty but has a docstring stating its purpose. The layering rules from ARCHITECTURE.md are enforceable by inspection.
+- `pyproject.toml` updated: new `[project.scripts]` entry `tycli = "_tycoon.cli:app"`, keeping existing `tycoon` entry untouched.
+- `ruff`, `mypy`/`pyright`, pytest configured. Pre-commit hooks installed.
+- One GitHub Actions workflow that runs lint + type-check + test on PRs.
+- `src/_tycoon/CLAUDE.md` written: load-bearing rules, layering constraints, where new things go.
+
+**Acceptance:**
+- `pip install -e .` succeeds.
+- `tycli --help` works and shows an empty Typer app (or a placeholder).
+- `pytest` runs, finds zero tests, exits 0.
+- `ruff check src/_tycoon/` is clean.
+- CI passes on PR.
+
+**Estimated effort:** half a day.
+
+### Step 2 — Protocols + one real dlt adapter, no CLI
+
+**Goal:** Prove the core abstractions hold against one real adapter before the CLI shape is locked in.
+
+**Concrete deliverables:**
+- `core/source.py` — `Source` dataclass with identity, runtime binding, handle, capability declarations.
+- `core/runtime.py` — **The `Runtime` Protocol — the single contract every Runtime implements.** Methods: `capabilities`, `catalog_offers`, `introspect`, `run`, `observe`, `read_state`. The dlt adapter built in this step is the *first* implementation, not a special case. Future runtimes (dlt-project, Fivetran, sling, Airbyte) implement the same Protocol without modifying `core/`.
+- `core/capabilities.py` — `Capability` enum and capability-set helpers.
+- `core/events.py` — Pydantic models for the metadata event schema (subset sufficient for ingestion runs).
+- `core/identifiers.py` — qualified IDs (e.g. `source:<name>@<runtime>`), parsing, formatting.
+- `core/metadata.py` — **The `MetadataBackend` Protocol and the Metadata API. Metadata is an abstract substrate with pluggable backing.** The DuckDB file backing built in this step is the cockpit default; the Protocol is designed against the second backing (writes into the user's Destination as a managed schema) from day one. Configuration surface includes which backing to use and any backing-specific options (file path for the file backing; connection + schema name for the Destination backing). User-overrideable via project manifest.
+- `metadata_backends/duckdb_file.py` — local DuckDB file backing. **First implementation of `MetadataBackend`, not the only shape the Protocol supports.** Configurable file path (with a sensible default — see open questions).
+- `metadata_backends/__init__.py` — backend registry. Selecting a backing is a configuration choice in the project manifest, not a hardcoded import.
+- `runtimes/dlt_native.py` — first dlt adapter. Start with REST API or one verified source (whichever is simpler to wire). Implements the full Runtime Protocol.
+- `runtimes/__init__.py` — runtime registry. Same pattern as `metadata_backends/`.
+- Unit tests on every `core/` module.
+- One integration test: invoke `dlt_native` runtime programmatically, ingest, write a metadata event to the file backing, read it back.
+- One contract test for `MetadataBackend`: a shared test suite that any backing implementation must pass. The file backing passes it now; future backings (Destination, in-memory for tests) pass it too. This is what keeps the contract honest.
+- One contract test for `Runtime`: same idea — a shared test suite every Runtime implementation passes.
+
+**Acceptance:**
+- `python -c "from _tycoon.runtimes.dlt_native import DltNativeRuntime; ..."` works.
+- A test executes ingestion end-to-end without any CLI in the loop.
+- Metadata events are written to `.tycoon/metadata.duckdb` (or the new path we settle on) and queryable.
+- `mypy --strict src/_tycoon/core/` passes.
+
+**Estimated effort:** ~1 week.
+
+**Why no CLI yet:** the CLI is a rendering of the model. The model has to be right first. If the CLI surfaces design decisions backward into `core/`, the model is wrong and we fix it before adding the second renderer.
+
+### Step 3 — CLI surface, designed top-down
+
+**Goal:** Phase 1 vertical slice working end-to-end through `tycli`.
+
+**Concrete deliverables (in this order):**
+- A separate short document — a command-tree sketch — reviewed before implementation. ASCII tree, each verb has a one-line purpose and a typed result shape. This is the deliberate CLI modeling exercise (D3).
+- `surfaces/cli/` implementations of: `attach`, `source add`, `source list`, `source show`, `source remove`, `run`, `status`.
+- Every command is a thin wrapper that parses intent, calls the core, returns a typed result.
+- `surfaces/json/` renderer that emits the typed result as JSON.
+- A CLI human-renderer that formats the same typed result as a table/tree/whatever fits.
+- `--json` flag on every command, emitting the JSON surface output unchanged.
+- One end-to-end test: `tycli attach` in an empty directory → `tycli source add <something>` → `tycli run <something>` → `tycli status`, verified via both the CLI and `--json`.
+- `scaffolds/manifest.py` and `scaffolds/dlt_native.py` implementing the strict scaffolder charter from MANIFESTO.md §9.
+
+**Acceptance:**
+- Phase 1 vertical slice from MANIFESTO.md §8 passes end-to-end.
+- An agent (or a curl-and-jq script) can read `--json` output, parse the result, and act on it.
+- Scaffolders create only what's needed, in the user's idiom, never mutate existing files, never re-run.
+
+**Estimated effort:** ~1 week.
+
+### Step 4 — Port the named patterns from `tycoon/`
+
+**Goal:** Lift the four pleasantly-surprising patterns from the old code. Each port is a small focused PR.
+
+**The port list (the entire list — nothing else gets ported):**
+
+1. **Metadata hook pattern** — `capture_dlt_safe`, `capture_dbt_safe`, etc. The fail-silent capture hook shape, adapted to the new event-shaped Metadata API.
+2. **Flat Pydantic source-config shape** — adapted into `core/source.py`, with `runtime` as a first-class field (the missing thing today).
+3. **Command-surface separation** — the discipline of keeping `add` / `remove` / `run` cleanly separated from scaffolding side-effects, ported to the new CLI shape.
+4. **Soft-fail capture pattern** — the silent-failure observability convention, used in the new `core/metadata.py` API as the default for non-critical writes.
+
+**Explicit don't-port list** — these are not coming over, ever, from the old code:
+- The FastAPI server (`commands/start.py`, `commands/stop.py`, `commands/services.py`)
+- The Dagster orchestration scaffolding (`orchestration/`)
+- The nao-core AI integration (`commands/ask.py`)
+- The dbt auto-scaffolding side effects on `run`
+- The existing flat command layout
+- The existing `CATALOG` static dict (replaced by federated Catalog query layer per ARCHITECTURE.md)
+- The shim-as-strings pattern from `source_manager.py` (replaced by adapter files)
+
+**Acceptance:** the four patterns are present in the new code, with tests, and the old code's equivalents are not referenced.
+
+**Estimated effort:** ~3-5 days.
+
+---
+
+## Phase 2 — The architectural acceptance test (after the four steps)
+
+After Step 4, the next milestone is adding the **Fivetran Runtime adapter** in `runtimes/fivetran.py`.
+
+**The acceptance test:** Fivetran is added with **zero changes to `src/_tycoon/core/`**. If a core change is needed, the Runtime Protocol is wrong and we fix the Protocol, not the Fivetran adapter. This is the architectural acceptance test from MANIFESTO.md §8 made concrete.
+
+If we cannot add Fivetran without touching `core/`, the abstractions are wrong and we stop and fix them before any more adapters get written. This is the moment of truth for the design.
+
+**Estimated effort:** ~1 week for the adapter itself; unknown if the Protocol needs revision.
+
+---
+
+## Cutover
+
+Triggered when Phase 2 passes — Fivetran adapter works, zero core changes were needed (or the Protocol was revised and both adapters now sit on the revised Protocol).
+
+**Cutover PR contents:**
+- Delete `src/tycoon/` (and tests, and Dagster/FastAPI/nao extras from `pyproject.toml`).
+- `git mv src/_tycoon src/tycoon`. Find-and-replace `_tycoon` → `tycoon` in imports.
+- `[project.scripts]`: remove old `tycoon` entry. Keep `tycli`. Optionally add `tycoon` as alias.
+- Update `README.md`, `CHANGELOG.md`, `MANIFESTO.md`, `ARCHITECTURE.md` to remove rewrite-window framing.
+- Bump major version.
+
+**Total estimated calendar effort, Step 1 through Cutover:** 4–6 weeks, depending on how clean Phase 2 lands.
+
+---
+
+## Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| The Runtime Protocol designed against dlt is wrong for Fivetran | Medium | Phase 2 is the deliberate test. We catch it before more adapters compound the mistake. |
+| Scope creep on the port — "let's also bring over X" | High | The port list is in writing. PRs that exceed it get rejected. |
+| Old `tycoon` package gets accidentally modified during rewrite | Low | Convention only — nobody assigns tickets against `src/tycoon/` during the rewrite window. Repo README will state this. |
+| CLI design decisions leak backward into `core/` | Medium | Step 2 builds and tests `core/` with no CLI in the loop. Step 3 is downstream of a finished Step 2. |
+| The four-pattern port list is incomplete — we discover a fifth pattern worth keeping | Medium | The port list can grow during Step 4 with a written justification, but each addition is reviewed against "does this actively shape the new code, or are we just sentimentally attached." |
+| Fivetran adapter requires core changes that retroactively break the dlt adapter | Low-Medium | Both adapters are exercised by their integration tests on every PR. A change that breaks one is rejected. |
+
+---
+
+## Open questions (to resolve during execution)
+
+These are intentionally unresolved here so they get decided in context rather than guessed in advance:
+
+1. **Metadata backing configuration surface.** What's the default file path for the DuckDB file backing (`.tycoon/metadata.duckdb` collides with old code; `.tycli/metadata.duckdb` is separate; something else)? More importantly, what's the project-manifest shape for choosing a non-default backing and configuring it? The Protocol must support file backing, Destination backing (post-POC), and an in-memory backing for tests from day one — but only the file backing needs to be *implemented* in Step 2. Settle the configuration shape so adding the Destination backing later is "one file in `metadata_backends/`, zero changes to the manifest schema."
+2. **Should `dlt-project` Runtime run in-process or in a subprocess?** Open question from ARCHITECTURE.md Level 3. Resolve when we wire the first user-supplied dlt project.
+3. **`commands/` vs `surfaces/cli/` as the folder for command implementations.** Decide in Step 3.
+4. **Static adapter registry vs. entry-point-based discovery.** Static is sufficient for the POC; defer entry-point discovery until a third party wants to ship an adapter.
+5. **Whether to introduce a common `Adapter` base Protocol** that Runtime / Transformation / Semantics / Presentation extend. Defer until at least one adapter exists in each folder (architecture open thread).
+6. **Cutover entrypoint:** keep `tycli` as primary, or rename to `tycoon` and demote `tycli` to alias. Decide at cutover based on what we've learned about usage.
+
+---
+
+## Appendix A — Inventory findings (summary)
+
+A focused diagnostic pass on the current `src/tycoon/` ingestion code categorized everything against the new vision: **Aligns / Bends / Breaks / Missing**. Full report available; summarized here.
+
+**Overall ratio:** ~15% aligns, ~50% bends, ~30% breaks, ~5% missing.
+
+**The three load-bearing assumptions in current code that most constrain a redirect:**
+1. `SourceConfig.type` conflates source-type with runtime — no runtime field exists.
+2. `runner.run_source()` has no runtime decision point; dlt is baked all the way through.
+3. Shims live inside `source_manager.py` as monolithic Python strings — new runtimes mean editing that file, not adding adapter files.
+
+**The four pleasantly-surprising things worth porting (the port list in §Step 4):**
+1. Metadata capture is already hook-shaped, soft-fail, runtime-agnostic in spirit.
+2. Command surface is cleanly separated from scaffolding side-effects.
+3. `SourceConfig` is flat Pydantic — straightforward to adapt.
+4. Optional extras (Dagster, FastAPI, nao-core) are properly scoped — they're in `[extras]`, not threaded through ingestion core.
+
+---
+
+## Status
+
+This plan reflects decisions taken between the manifesto/architecture conversations and the start of execution, as of 2026-06-28. Once vetted internally, it becomes the basis of a GitHub issue for Stephen's review and ongoing tracking.
+
+**Next action after sign-off:** open the GitHub issue, then begin Step 1.

--- a/docs/proposals/_tycoon/PLAN.md
+++ b/docs/proposals/_tycoon/PLAN.md
@@ -8,9 +8,9 @@
 
 ## TL;DR
 
-We are rewriting the ingestion layer of `tycoon-cli` against the abstractions in MANIFESTO.md and ARCHITECTURE.md. Two existing packages will coexist in this repo during the rewrite: `src/tycoon/` (current production code, entrypoint `tycoon`) and `src/_tycoon/` (the rewrite, entrypoint `tycli`). When the rewrite reaches feature parity for ingestion and passes the architectural acceptance test (Fivetran adapter slotted in with zero core changes), we cut over in a single PR: delete `src/tycoon/`, rename `src/_tycoon/` → `src/tycoon/`. The `tycli` entrypoint stays as either an alias or the primary command depending on what we've learned by then.
+We are rewriting the ingestion layer of `tycoon-cli` against the abstractions in MANIFESTO.md and ARCHITECTURE.md. The rewrite happens directly in `src/tycoon/` on a long-lived feature branch. When it reaches feature parity for ingestion and passes the architectural acceptance test (Fivetran adapter slotted in with zero core changes), the branch merges. No parallel package, no shadow entrypoint, no cutover rename.
 
-The decision to rewrite rather than refactor was made after a focused inventory pass (Appendix A). The current code is ~50% reshapeable, ~30% actively contradicts the new shape, and the load-bearing assumptions (source-type conflated with runtime, dispatch hardcoded to dlt, shims monolithic) are exactly the assumptions the new abstractions exist to remove. Refactoring in-place would force a months-long half-converted state. Rewriting in parallel keeps the production CLI working while the new shape is built deliberately.
+The decision to rewrite rather than refactor was made after a focused inventory pass (Appendix A). The current code is ~50% reshapeable, ~30% actively contradicts the new shape, and the load-bearing assumptions (source-type conflated with runtime, dispatch hardcoded to dlt, shims monolithic) are exactly the assumptions the new abstractions exist to remove. Refactoring in-place on main would force a months-long half-converted state. Rewriting on a dedicated branch keeps main stable while the new shape is built deliberately — and with ~17 PyPI downloads/day and no production users, there is no coexistence requirement that would justify the complexity of a parallel package.
 
 ---
 
@@ -18,26 +18,19 @@ The decision to rewrite rather than refactor was made after a focused inventory 
 
 These are settled. Each is recorded here so the rationale is durable.
 
-### D1 — Rewrite path: extract a new package, port the good parts
+### D1 — Rewrite path: rebuild in `src/tycoon/` on a feature branch
 
-Build a new package at `src/_tycoon/` from scratch against the manifesto and architecture. The old `src/tycoon/` remains untouched in the same repo as a working fallback. Four specific patterns from the old code will be ported deliberately (see §"Port list"). Everything else either gets rebuilt with the right shape or stays out.
+Rebuild the ingestion layer from scratch against the manifesto and architecture, directly in `src/tycoon/`, on a long-lived feature branch. Four specific patterns from the old code will be ported deliberately (see §"Port list"). Everything else either gets rebuilt with the right shape or stays out.
 
-**Why not refactor in place:** half-converted codebases die of contortion. Every PR becomes "rename this, gate that, add a flag." The load-bearing assumptions in the current code are exactly what the new abstractions remove — fighting them in-flight is slower than rebuilding cleanly.
+**Why rewrite, not refactor:** half-converted codebases die of contortion. Every PR becomes "rename this, gate that, add a flag." The load-bearing assumptions in the current code are exactly what the new abstractions exist to remove — fighting them in-flight is slower than rebuilding cleanly.
 
-**Why not pure greenfield in a separate repo:** we'd lose the four patterns worth porting, lose the git history, and create a coordination problem (two repos to track, two PyPI distributions to reconcile). Same-repo coexistence is cheaper.
+**Why in-place, not a parallel package:** the parallel-package approach (a separate `src/_tycoon/` with a shadow `tycli` entrypoint and a cutover PR) adds machinery nobody needs. With ~17 PyPI downloads/day and no production users, keeping the old CLI "working untouched" buys safety no one requires. A feature branch achieves the clean-room property without a second package name living in the tree.
 
-**Why the install-base does not constrain:** ~17 PyPI downloads/day, no known production users. The team is the entire user base. No coexistence-for-users requirement.
+**Why not a separate repo:** we'd lose the four patterns worth porting, lose the git history, and create a coordination problem. Same-repo feature branch is cheaper.
 
 ### D2 — Package and entrypoint naming
 
-| Surface | During rewrite window | At cutover |
-|---|---|---|
-| Import path | `_tycoon` | `tycoon` |
-| Filesystem | `src/_tycoon/` | `src/tycoon/` (old deleted) |
-| Entrypoint command | `tycli` | `tycli` (alias) and/or `tycoon` (decide at cutover) |
-| PyPI distribution | unchanged (`database-tycoon`) | unchanged unless we rename deliberately |
-
-The leading underscore is the explicit "in-progress, will-be-renamed" marker. It cannot be invoked by accident through `tycoon`. The entrypoint is decoupled from the import name from day one — that decoupling is permanent, not just a rewrite-window convenience. We never again confuse "what the package is called internally" with "what the user types."
+One name throughout: `tycoon`. CLI command, import path, filesystem path, PyPI distribution (`database-tycoon`) unchanged. No rewrite-window aliases, no cutover rename.
 
 ### D3 — CLI as a thin shell over a programmatic API
 
@@ -46,7 +39,7 @@ Every command returns a typed result. The CLI renderer formats it for humans; th
 **What this means concretely:**
 - No command function "prints a table." It returns a structured result object; a renderer prints the table.
 - `--json` works on every command by default, emitting the same model the CLI rendered.
-- `from _tycoon import sources; sources.add(...)` gives an experience equivalent to `tycli source add ...`.
+- `from tycoon import sources; sources.add(...)` gives an experience equivalent to `tycoon source add ...`.
 - This is the manifesto §5 (agent-latchability) commitment made concrete from day one. Retrofitting later is much harder than building toward it.
 
 ### D4 — Quality scaffolding from day one, proportionate
@@ -60,24 +53,26 @@ Every command returns a typed result. The CLI renderer formats it for humans; th
 | Type checking | mypy or pyright in strict mode on `core/`; looser on adapters where third-party stubs are weak |
 | CI | One GitHub Actions workflow: lint + type-check + test on PRs |
 | Pre-commit hooks | ruff format + ruff check + mypy on changed files |
-| `CLAUDE.md` | At `src/_tycoon/` root. Short (under 200 lines). Covers manifesto's load-bearing rules, layering constraints, "where new things go," test/lint expectations |
+| `CLAUDE.md` | At `src/tycoon/` root. Short (under 200 lines). Covers manifesto's load-bearing rules, layering constraints, "where new things go," test/lint expectations |
 
 Done first, before any business logic. Empty package, working CI, working pre-commit, empty `CLAUDE.md`. Sets the tone.
 
-### D5 — POC scope: ingestion only, two Runtimes, three modes
+### D5 — POC scope: ingestion + dbt Transformation, two Runtimes, three modes
 
-Per manifesto §8. The rewrite ships exactly two Runtime adapters in the POC:
+Per manifesto §8 and ARCHITECTURE.md Level 3. The rewrite ships exactly two Runtime adapters in the POC:
 
 - **dlt** — execution in-process (or in a controlled subprocess for `dlt-project`)
-- **Fivetran** — execution delegated; dbty observes and triggers via API
+- **Fivetran** — execution delegated; tycoon observes and triggers via API
 
 From those, three Source modes:
 
-1. **`dlt-native`** — dbty runs a dlt source or resource (own shim or user entrypoint)
-2. **`dlt-project`** — dbty wraps a user's existing dlt project
-3. **`fivetran`** — dbty observes and triggers a Fivetran connector via API
+1. **`dlt-native`** — tycoon runs a dlt source or resource (own shim or user entrypoint)
+2. **`dlt-project`** — tycoon wraps a user's existing dlt project
+3. **`fivetran`** — tycoon observes and triggers a Fivetran connector via API
 
-**Out of scope for this rewrite:** Transformation, Semantics, Presentation, additional Surfaces (MCP, TUI, web). The architecture has homes for these; they are built after Phase 2 lands.
+**dbt (Transformation) is also in POC scope.** ARCHITECTURE.md already lists `transformations/dbt.py` as a POC adapter. Including it is the right call: it exercises a second adapter shape (Transformation, not just Runtime), which is exactly the "is this abstraction real or coincidence" check the design rests on. A Runtime Protocol designed against one compartment type is a hypothesis; a second compartment implementing the same shape is evidence.
+
+**Out of scope for this rewrite:** Semantics, Presentation, additional Surfaces (MCP, TUI, web), additional Runtimes beyond dlt and Fivetran. The architecture has homes for these; they are built after Phase 2 lands.
 
 ---
 
@@ -90,18 +85,18 @@ Four steps, in order. Each has a concrete acceptance criterion. No step starts u
 **Goal:** Empty package with all quality scaffolding working. No business logic.
 
 **Concrete deliverables:**
-- `src/_tycoon/` directory with the layout from ARCHITECTURE.md §"Level 4 — Code" (`core/`, `runtimes/`, `destinations/`, `metadata_backends/`, `scaffolds/`, `surfaces/cli/`, `surfaces/json/`).
+- `src/tycoon/` directory with the layout from ARCHITECTURE.md §"Level 4 — Code" (`core/`, `runtimes/`, `destinations/`, `metadata_backends/`, `scaffolds/`, `surfaces/cli/`, `surfaces/json/`).
 - Every module is empty but has a docstring stating its purpose. The layering rules from ARCHITECTURE.md are enforceable by inspection.
-- `pyproject.toml` updated: new `[project.scripts]` entry `tycli = "_tycoon.cli:app"`, keeping existing `tycoon` entry untouched.
+- `pyproject.toml` updated: `[project.scripts]` entry `tycoon = "tycoon.cli:app"` (same entrypoint name, new target module).
 - `ruff`, `mypy`/`pyright`, pytest configured. Pre-commit hooks installed.
 - One GitHub Actions workflow that runs lint + type-check + test on PRs.
-- `src/_tycoon/CLAUDE.md` written: load-bearing rules, layering constraints, where new things go.
+- `src/tycoon/CLAUDE.md` written: load-bearing rules, layering constraints, where new things go.
 
 **Acceptance:**
 - `pip install -e .` succeeds.
-- `tycli --help` works and shows an empty Typer app (or a placeholder).
+- `tycoon --help` works and shows an empty Typer app (or a placeholder).
 - `pytest` runs, finds zero tests, exits 0.
-- `ruff check src/_tycoon/` is clean.
+- `ruff check src/tycoon/` is clean.
 - CI passes on PR.
 
 **Estimated effort:** half a day.
@@ -127,10 +122,10 @@ Four steps, in order. Each has a concrete acceptance criterion. No step starts u
 - One contract test for `Runtime`: same idea — a shared test suite every Runtime implementation passes.
 
 **Acceptance:**
-- `python -c "from _tycoon.runtimes.dlt_native import DltNativeRuntime; ..."` works.
+- `python -c "from tycoon.runtimes.dlt_native import DltNativeRuntime; ..."` works.
 - A test executes ingestion end-to-end without any CLI in the loop.
-- Metadata events are written to `.tycoon/metadata.duckdb` (or the new path we settle on) and queryable.
-- `mypy --strict src/_tycoon/core/` passes.
+- Metadata events are written to `.tycoon/metadata.duckdb` and queryable.
+- `mypy --strict src/tycoon/core/` passes.
 
 **Estimated effort:** ~1 week.
 
@@ -138,16 +133,17 @@ Four steps, in order. Each has a concrete acceptance criterion. No step starts u
 
 ### Step 3 — CLI surface, designed top-down
 
-**Goal:** Phase 1 vertical slice working end-to-end through `tycli`.
+**Goal:** Phase 1 vertical slice working end-to-end through `tycoon`.
 
 **Concrete deliverables (in this order):**
 - A separate short document — a command-tree sketch — reviewed before implementation. ASCII tree, each verb has a one-line purpose and a typed result shape. This is the deliberate CLI modeling exercise (D3).
 - `surfaces/cli/` implementations of: `attach`, `source add`, `source list`, `source show`, `source remove`, `run`, `status`.
+
 - Every command is a thin wrapper that parses intent, calls the core, returns a typed result.
 - `surfaces/json/` renderer that emits the typed result as JSON.
 - A CLI human-renderer that formats the same typed result as a table/tree/whatever fits.
 - `--json` flag on every command, emitting the JSON surface output unchanged.
-- One end-to-end test: `tycli attach` in an empty directory → `tycli source add <something>` → `tycli run <something>` → `tycli status`, verified via both the CLI and `--json`.
+- One end-to-end test: `tycoon attach` in an empty directory → `tycoon source add <something>` → `tycoon run <something>` → `tycoon status`, verified via both the CLI and `--json`.
 - `scaffolds/manifest.py` and `scaffolds/dlt_native.py` implementing the strict scaffolder charter from MANIFESTO.md §9.
 
 **Acceptance:**
@@ -187,7 +183,9 @@ Four steps, in order. Each has a concrete acceptance criterion. No step starts u
 
 After Step 4, the next milestone is adding the **Fivetran Runtime adapter** in `runtimes/fivetran.py`.
 
-**The acceptance test:** Fivetran is added with **zero changes to `src/_tycoon/core/`**. If a core change is needed, the Runtime Protocol is wrong and we fix the Protocol, not the Fivetran adapter. This is the architectural acceptance test from MANIFESTO.md §8 made concrete.
+**The acceptance test:** Fivetran is added with **zero changes to `src/tycoon/core/`**. If a core change is needed, the Runtime Protocol is wrong and we fix the Protocol, not the Fivetran adapter. This is the architectural acceptance test from MANIFESTO.md §8 made concrete.
+
+**The specific failure mode to watch for:** dlt emits a live event stream during a run; Fivetran can only poll. If that push-vs-pull difference leaks into `core/` as a Fivetran special-case — an `if fivetran: poll()` branch, a second event-ingestion path, anything that treats Fivetran differently at the protocol level — the abstraction quietly failed even though the code works. The Runtime Protocol must model the difference explicitly (e.g. `observe()` returns an iterator that either streams or polls under the hood, the caller never knows which), not paper over it with a conditional. If we cannot make that work without touching `core/`, stop and fix the Protocol.
 
 If we cannot add Fivetran without touching `core/`, the abstractions are wrong and we stop and fix them before any more adapters get written. This is the moment of truth for the design.
 
@@ -195,18 +193,16 @@ If we cannot add Fivetran without touching `core/`, the abstractions are wrong a
 
 ---
 
-## Cutover
+## Merge
 
 Triggered when Phase 2 passes — Fivetran adapter works, zero core changes were needed (or the Protocol was revised and both adapters now sit on the revised Protocol).
 
-**Cutover PR contents:**
-- Delete `src/tycoon/` (and tests, and Dagster/FastAPI/nao extras from `pyproject.toml`).
-- `git mv src/_tycoon src/tycoon`. Find-and-replace `_tycoon` → `tycoon` in imports.
-- `[project.scripts]`: remove old `tycoon` entry. Keep `tycli`. Optionally add `tycoon` as alias.
+**Merge PR contents:**
+- Remove Dagster/FastAPI/nao extras from `pyproject.toml` (per the don't-port list in §Step 4).
 - Update `README.md`, `CHANGELOG.md`, `MANIFESTO.md`, `ARCHITECTURE.md` to remove rewrite-window framing.
 - Bump major version.
 
-**Total estimated calendar effort, Step 1 through Cutover:** 4–6 weeks, depending on how clean Phase 2 lands.
+**Total estimated calendar effort, Step 1 through Merge:** 4–6 weeks, depending on how clean Phase 2 lands.
 
 ---
 
@@ -215,8 +211,8 @@ Triggered when Phase 2 passes — Fivetran adapter works, zero core changes were
 | Risk | Likelihood | Mitigation |
 |---|---|---|
 | The Runtime Protocol designed against dlt is wrong for Fivetran | Medium | Phase 2 is the deliberate test. We catch it before more adapters compound the mistake. |
+| Push-vs-pull difference leaks into `core/` as a Fivetran special-case | Medium | `observe()` must model streaming and polling uniformly — the caller never sees which. If a conditional appears in `core/`, treat it as a Protocol failure and fix the interface. |
 | Scope creep on the port — "let's also bring over X" | High | The port list is in writing. PRs that exceed it get rejected. |
-| Old `tycoon` package gets accidentally modified during rewrite | Low | Convention only — nobody assigns tickets against `src/tycoon/` during the rewrite window. Repo README will state this. |
 | CLI design decisions leak backward into `core/` | Medium | Step 2 builds and tests `core/` with no CLI in the loop. Step 3 is downstream of a finished Step 2. |
 | The four-pattern port list is incomplete — we discover a fifth pattern worth keeping | Medium | The port list can grow during Step 4 with a written justification, but each addition is reviewed against "does this actively shape the new code, or are we just sentimentally attached." |
 | Fivetran adapter requires core changes that retroactively break the dlt adapter | Low-Medium | Both adapters are exercised by their integration tests on every PR. A change that breaks one is rejected. |
@@ -227,12 +223,12 @@ Triggered when Phase 2 passes — Fivetran adapter works, zero core changes were
 
 These are intentionally unresolved here so they get decided in context rather than guessed in advance:
 
-1. **Metadata backing configuration surface.** What's the default file path for the DuckDB file backing (`.tycoon/metadata.duckdb` collides with old code; `.tycli/metadata.duckdb` is separate; something else)? More importantly, what's the project-manifest shape for choosing a non-default backing and configuring it? The Protocol must support file backing, Destination backing (post-POC), and an in-memory backing for tests from day one — but only the file backing needs to be *implemented* in Step 2. Settle the configuration shape so adding the Destination backing later is "one file in `metadata_backends/`, zero changes to the manifest schema."
+1. **Metadata backing configuration surface.** Default path is `.tycoon/metadata.duckdb`. More importantly, what's the project-manifest shape for choosing a non-default backing and configuring it? The Protocol must support file backing, Destination backing (post-POC), and an in-memory backing for tests from day one — but only the file backing needs to be *implemented* in Step 2. Settle the configuration shape so adding the Destination backing later is "one file in `metadata_backends/`, zero changes to the manifest schema."
 2. **Should `dlt-project` Runtime run in-process or in a subprocess?** Open question from ARCHITECTURE.md Level 3. Resolve when we wire the first user-supplied dlt project.
 3. **`commands/` vs `surfaces/cli/` as the folder for command implementations.** Decide in Step 3.
 4. **Static adapter registry vs. entry-point-based discovery.** Static is sufficient for the POC; defer entry-point discovery until a third party wants to ship an adapter.
 5. **Whether to introduce a common `Adapter` base Protocol** that Runtime / Transformation / Semantics / Presentation extend. Defer until at least one adapter exists in each folder (architecture open thread).
-6. **Cutover entrypoint:** keep `tycli` as primary, or rename to `tycoon` and demote `tycli` to alias. Decide at cutover based on what we've learned about usage.
+6. **Cutover entrypoint:** `tycoon` is the command. Resolved.
 
 ---
 

--- a/docs/proposals/_tycoon/README.md
+++ b/docs/proposals/_tycoon/README.md
@@ -1,0 +1,21 @@
+# Proposal: Tycoon CLI rewrite (`_tycoon`)
+
+This folder holds the three-document proposal for rewriting the Tycoon CLI's ingestion layer (and laying foundations for the rest of the control plane) under a new set of abstractions.
+
+The documents are layered — read top-to-bottom for a complete picture, or pick the altitude that matches the decision you're trying to make.
+
+| Document | Altitude | What it answers |
+|---|---|---|
+| [MANIFESTO.md](./MANIFESTO.md) | Philosophy | *Why* are we doing this? *What shape* is the system meant to take? |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | Structure (C4) | *How is it built?* From system boundary down to the proposed source tree. |
+| [PLAN.md](./PLAN.md) | Execution | *What are we actually doing about it?* Decisions, sequencing, acceptance criteria, risks. |
+
+## Status
+
+**Draft proposal.** Discussion happens on the accompanying GitHub issue; this folder is the artifact reviewers point at for detail. Updates land here as the proposal evolves.
+
+## Naming note
+
+The author used `dbty` / `dbty-cli` in conversation as personal shorthand for **Database Tycoon** (the company). All three documents preserve that shorthand where rewriting would obscure the original framing — but the tool itself is the **Tycoon CLI** (repo `tycoon-cli`, distributed on PyPI as `database-tycoon`). It is not a separate product, not a dbt fork, and not affiliated with dlt.
+
+The proposal also introduces `tycli` as a placeholder entrypoint command during the rewrite window so the new code cannot be invoked accidentally through the production `tycoon` command. See [PLAN.md §D2](./PLAN.md#d2--package-and-entrypoint-naming) for the naming-and-cutover plan.


### PR DESCRIPTION
Refs #79

## Summary

Draft proposal for rewriting the Tycoon CLI's ingestion layer (and laying foundations for the rest of the control plane) under a new set of abstractions. **This PR is the artifact** — three documents and an index — not an implementation. Discussion happens on the accompanying issue; reviewers point here for detail.

The proposal pursues a **stack-aware control plane** positioning (BYOS, agent-latchable, deliberately *not* a platform). Adjacent tools in the category are platform-shaped; the proposal makes the control-plane vs. platform distinction load-bearing and uses it to constrain every subsequent design choice.

## What's in this PR

| File | What it is |
|---|---|
| [`docs/proposals/_tycoon/MANIFESTO.md`](docs/proposals/_tycoon/MANIFESTO.md) | Philosophy and shape — control plane vs. platform, BYOS, the nine compartments (Source / Runtime / Destination / Transformation / Semantics / Presentation / Metadata / Catalog / Surface), progressive disclosure, the scaffolding charter |
| [`docs/proposals/_tycoon/ARCHITECTURE.md`](docs/proposals/_tycoon/ARCHITECTURE.md) | C4-shaped structure: System Context → Containers → Components → Code. Adapter interface sketches, layering rules, proposed source tree |
| [`docs/proposals/_tycoon/PLAN.md`](docs/proposals/_tycoon/PLAN.md) | Execution plan: rewrite-not-refactor decision, naming (`_tycoon` during rewrite window, `tycli` entrypoint, cutover criteria), four-step sequencing, port list and don't-port list, risks |
| [`docs/proposals/_tycoon/README.md`](docs/proposals/_tycoon/README.md) | Index pointing readers at the three docs in reading order |

## The decisions this proposal asks reviewers to react to

1. **Positioning** — control plane, not platform (MANIFESTO §1)
2. **BYOS** — meet existing stacks where they live (MANIFESTO §2)
3. **POC scope** — dlt + Fivetran as two Runtime adapters, three modes (MANIFESTO §8)
4. **Rewrite path** — extract a new package at `src/_tycoon/`, port four named patterns from `src/tycoon/`, cutover when Fivetran adapter lands with zero core changes (PLAN §D1)
5. **CLI shape** — thin shell over a typed programmatic API, every command emits the same model to humans and agents (PLAN §D3)

## What this PR does *not* do

- No code changes outside the docs folder
- No changes to the existing `src/tycoon/` package
- No changes to existing entrypoints or PyPI distribution

## Status

**Draft.** Iterating in response to issue discussion. Marked ready-for-review once the proposal stabilizes; merged once the team aligns on direction. Implementation work happens in subsequent PRs, scoped against [PLAN.md](docs/proposals/_tycoon/PLAN.md)'s four-step sequencing.

## Naming note

The author used `dbty` / `dbty-cli` in conversation as personal shorthand for **Database Tycoon** (the company). All three documents preserve that shorthand where rewriting would obscure the original framing. The tool itself is the **Tycoon CLI** (repo `tycoon-cli`, PyPI `database-tycoon`). The README and the top of each document make this explicit.

## Test plan

- [ ] Files render correctly on GitHub (no broken Markdown or ASCII diagrams)
- [ ] Internal links between the three docs resolve
- [ ] Naming-note callouts at the top of each doc are visible and unambiguous

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Database-Tycoon/codesmith/tycoon-cli/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785281661&installation_id=139583274&pr_number=78&repository=Database-Tycoon%2Ftycoon-cli&return_to=https%3A%2F%2Fgithub.com%2FDatabase-Tycoon%2Ftycoon-cli%2Fpull%2F78&signature=c6824b625f73ce5a7e36c7e450bc2370ee1646b358929e70a9bf0372abd31b1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
