### PR TITLE
feat(m1): wire run events into commands (Task 2/2)

### DIFF
--- a/src/tycoon/commands/history.py
+++ b/src/tycoon/commands/history.py
@@ -157,7 +157,7 @@ def _list_history(
     try:
         with DuckDBFileBackend(meta, read_only=True) as b:
             repo = HistoryRepository(b)
-            runs = repo.list_runs(limit=limit * 3)
+            runs = repo.list_runs(limit=None)
     except Exception:
         runs = []
 

--- a/src/tycoon/commands/history.py
+++ b/src/tycoon/commands/history.py
@@ -20,7 +20,7 @@ from rich.table import Table
 from tycoon.config import config
 from tycoon.core.history import HistoryRepository, RunSummary
 from tycoon.observability import metadata_db_path
-from tycoon.utils.console import console, error, header, info, warn
+from tycoon.utils.console import console, error, header, info
 
 
 app = typer.Typer(

--- a/src/tycoon/commands/history.py
+++ b/src/tycoon/commands/history.py
@@ -14,11 +14,11 @@ from __future__ import annotations
 import datetime
 from pathlib import Path
 
-import duckdb
 import typer
 from rich.table import Table
 
 from tycoon.config import config
+from tycoon.core.history import HistoryRepository, RunSummary
 from tycoon.observability import metadata_db_path
 from tycoon.utils.console import console, error, header, info, warn
 
@@ -77,152 +77,7 @@ def _short(id_value: str, n: int = 8) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _load_dlt_rows(
-    con: duckdb.DuckDBPyConnection,
-    limit: int,
-    source_schema: str | None = None,
-) -> list[tuple]:
-    """Return the most recent dlt runs with total rows loaded per load.
-
-    If ``source_schema`` is given, only loads for that schema are returned.
-
-    Tuple shape: (when_ts, tool, ref, full_id, ok, detail_str)
-    """
-    if source_schema:
-        rows = con.execute(
-            """
-            SELECT
-                r.inserted_at,
-                r.source_schema,
-                r.load_id,
-                r.status,
-                COALESCE(t.rows_total, 0) AS rows_total,
-                COALESCE(t.table_count, 0) AS table_count
-            FROM dlt_runs r
-            LEFT JOIN (
-                SELECT source_schema, load_id,
-                       SUM(rows_loaded) AS rows_total,
-                       COUNT(DISTINCT table_name) AS table_count
-                FROM dlt_rows_by_table
-                GROUP BY source_schema, load_id
-            ) t USING (source_schema, load_id)
-            WHERE r.source_schema = ?
-            ORDER BY r.inserted_at DESC NULLS LAST
-            LIMIT ?
-            """,
-            [source_schema, limit],
-        ).fetchall()
-    else:
-        rows = con.execute(
-            """
-            SELECT
-                r.inserted_at,
-                r.source_schema,
-                r.load_id,
-                r.status,
-                COALESCE(t.rows_total, 0) AS rows_total,
-                COALESCE(t.table_count, 0) AS table_count
-            FROM dlt_runs r
-            LEFT JOIN (
-                SELECT source_schema, load_id,
-                       SUM(rows_loaded) AS rows_total,
-                       COUNT(DISTINCT table_name) AS table_count
-                FROM dlt_rows_by_table
-                GROUP BY source_schema, load_id
-            ) t USING (source_schema, load_id)
-            ORDER BY r.inserted_at DESC NULLS LAST
-            LIMIT ?
-            """,
-            [limit],
-        ).fetchall()
-
-    out: list[tuple] = []
-    for inserted_at, schema, load_id, status, rows_total, table_count in rows:
-        ok = status == 0
-        detail = f"{schema} · {table_count} tables · {rows_total:,} rows"
-        out.append((inserted_at, "dlt", f"{schema}/{_short(load_id)}", load_id, ok, detail))
-    return out
-
-
-def _load_dbt_rows(
-    con: duckdb.DuckDBPyConnection,
-    limit: int,
-    *,
-    model_names: list[str] | None = None,
-) -> list[tuple]:
-    """Load dbt runs.
-
-    When ``model_names`` is provided, restrict to invocations that touched
-    at least one of those models (used by ``--layer`` filtering).
-    """
-    if model_names:
-        rows = con.execute(
-            """
-            SELECT
-                r.started_at,
-                r.command,
-                r.invocation_id,
-                r.success,
-                r.elapsed_s,
-                r.models_ok,
-                r.models_error,
-                r.tests_passed,
-                r.tests_failed
-            FROM dbt_runs r
-            WHERE EXISTS (
-                SELECT 1 FROM dbt_nodes n
-                WHERE n.invocation_id = r.invocation_id
-                  AND list_contains(?, n.node_name)
-            )
-            ORDER BY r.started_at DESC NULLS LAST
-            LIMIT ?
-            """,
-            [model_names, limit],
-        ).fetchall()
-    else:
-        rows = con.execute(
-            """
-            SELECT
-                started_at,
-                command,
-                invocation_id,
-                success,
-                elapsed_s,
-                models_ok,
-                models_error,
-                tests_passed,
-                tests_failed
-            FROM dbt_runs
-            ORDER BY started_at DESC NULLS LAST
-            LIMIT ?
-            """,
-            [limit],
-        ).fetchall()
-
-    out: list[tuple] = []
-    for (
-        started_at,
-        command,
-        invocation_id,
-        success,
-        elapsed_s,
-        models_ok,
-        models_error,
-        tests_passed,
-        tests_failed,
-    ) in rows:
-        detail_parts: list[str] = [f"{_fmt_duration(elapsed_s)}"]
-        if models_ok or models_error:
-            detail_parts.append(f"{models_ok} ok / {models_error} err")
-        if tests_passed or tests_failed:
-            detail_parts.append(f"{tests_passed} pass / {tests_failed} fail")
-        detail = " · ".join(detail_parts)
-        ref = f"{command} ({_short(invocation_id)})" if command else _short(invocation_id)
-        out.append((started_at, "dbt", ref, invocation_id, bool(success), detail))
-    return out
-
-
-def _render_history_table(combined: list[tuple]) -> Table:
+def _render_history_table(runs: list[RunSummary]) -> Table:
     table = Table(show_lines=False)
     table.add_column("When", style="dim", no_wrap=True)
     table.add_column("Tool", style="bold")
@@ -230,29 +85,28 @@ def _render_history_table(combined: list[tuple]) -> Table:
     table.add_column("Status", justify="center")
     table.add_column("Details")
 
-    for when_ts, tool, ref, _full_id, ok, detail in combined:
-        status_str = "[green]✓[/green]" if ok else "[red]✗[/red]"
-        tool_style = "[bold cyan]dlt[/bold cyan]" if tool == "dlt" else "[bold magenta]dbt[/bold magenta]"
-        table.add_row(_fmt_ts(when_ts), tool_style, ref, status_str, detail)
+    for s in runs:
+        is_dbt = s.runtime_id == "dbt"
+        tool_style = (
+            "[bold magenta]dbt[/bold magenta]"
+            if is_dbt
+            else "[bold cyan]dlt[/bold cyan]"
+        )
+        status_str = "[green]✓[/green]" if s.status == "success" else "[red]✗[/red]"
+
+        if is_dbt:
+            cmd = s.command or "run"
+            ref = f"{cmd} ({_short(s.run_id)})"
+            detail = _fmt_duration(s.duration_seconds)
+            if s.rows_total:
+                detail += f" · {s.rows_total} models"
+        else:
+            ref = f"{s.source_id}/{_short(s.run_id)}"
+            detail = f"{s.rows_total:,} rows"
+
+        table.add_row(_fmt_ts(s.started_at), tool_style, ref, status_str, detail)
 
     return table
-
-
-def _resolve_source_schema(source: str) -> str:
-    """Translate a source name into its schema.
-
-    If ``source`` matches a name in ``tycoon.yml``'s sources map, return its
-    ``schema_name``. Otherwise treat it as a literal schema name. This lets
-    users say ``--source pokeapi`` (config name) or ``--source raw_pokeapi``
-    (schema literal) interchangeably.
-    """
-    try:
-        src = config.sources.get(source)
-        if src is not None:
-            return src.schema_name
-    except Exception:
-        pass
-    return source
 
 
 def _resolve_layer_models(layer: str) -> list[str]:
@@ -298,50 +152,48 @@ def _list_history(
 
     meta = _metadata_or_exit()
 
-    source_schema = _resolve_source_schema(source) if source else None
+    from tycoon.metadata_backends.duckdb_file import DuckDBFileBackend
 
-    con = duckdb.connect(str(meta), read_only=True)
     try:
-        combined: list[tuple] = []
-        # ``--layer`` only filters dbt invocations -- dlt loads aren't
-        # classifiable into staging/intermediate/mart.
-        if tool in ("all", "dlt") and layer_models is None:
-            combined.extend(_load_dlt_rows(con, limit, source_schema=source_schema))
-        # dbt runs aren't source-scoped (a build touches all models), so when
-        # the user asks for a specific source we hide dbt entirely rather
-        # than polluting the view with unfiltered invocations.
-        if tool in ("all", "dbt") and source_schema is None:
-            combined.extend(_load_dbt_rows(con, limit, model_names=layer_models))
-    finally:
-        con.close()
+        with DuckDBFileBackend(meta, read_only=True) as b:
+            repo = HistoryRepository(b)
+            runs = repo.list_runs(limit=limit * 3)
+    except Exception:
+        runs = []
 
-    if not combined:
+    if tool == "dlt":
+        runs = [r for r in runs if r.runtime_id != "dbt"]
+    elif tool == "dbt":
+        runs = [r for r in runs if r.runtime_id == "dbt"]
+
+    if source is not None:
+        runs = [r for r in runs if r.source_id == source and r.runtime_id != "dbt"]
+    elif layer_models is not None:
+        # --layer restricts to dbt runs only; per-model filtering requires
+        # per-node event detail added in a later milestone.
+        runs = [r for r in runs if r.runtime_id == "dbt"]
+
+    runs = runs[:limit]
+
+    if not runs:
         if layer_models is not None:
             info(
-                f"No dbt invocations captured that touched the [bold]{layer}[/bold] "
+                f"No dbt invocations captured for the [bold]{layer}[/bold] "
                 "layer yet."
             )
-        elif source_schema:
-            info(
-                f"No dlt runs captured for source schema [bold]{source_schema}[/bold]."
-            )
+        elif source is not None:
+            info(f"No dlt runs captured for source [bold]{source}[/bold].")
         else:
             info("No runs captured yet for the selected tool(s).")
         return
 
-    combined.sort(
-        key=lambda r: r[0] or datetime.datetime.min.replace(tzinfo=datetime.timezone.utc),
-        reverse=True,
-    )
-    combined = combined[:limit]
-
     title = "Run History"
-    if source_schema:
-        title += f" — {source_schema}"
+    if source is not None:
+        title += f" — {source}"
     elif layer_models is not None:
         title += f" — {layer} layer"
     header(title)
-    console.print(_render_history_table(combined))
+    console.print(_render_history_table(runs))
     console.print()
     info("Drill in with [bold]tycoon data history show <id>[/bold] (short prefix OK).")
 
@@ -351,274 +203,55 @@ def _list_history(
 # ---------------------------------------------------------------------------
 
 
-def _resolve_id(
-    con: duckdb.DuckDBPyConnection, id_prefix: str
-) -> tuple[str, str] | None:
-    """Resolve a short-prefix id to ('dlt', load_id) or ('dbt', invocation_id)."""
-    dlt_matches = con.execute(
-        "SELECT source_schema, load_id FROM dlt_runs WHERE load_id LIKE ? LIMIT 2",
-        [f"{id_prefix}%"],
-    ).fetchall()
-    dbt_matches = con.execute(
-        "SELECT invocation_id FROM dbt_runs WHERE invocation_id LIKE ? LIMIT 2",
-        [f"{id_prefix}%"],
-    ).fetchall()
-
-    total = len(dlt_matches) + len(dbt_matches)
-    if total == 0:
-        return None
-    if total > 1:
-        samples: list[str] = [f"dlt/{m[1]}" for m in dlt_matches[:2]]
-        samples.extend(f"dbt/{m[0]}" for m in dbt_matches[:2])
-        warn(f"Prefix '{id_prefix}' is ambiguous — matches: {', '.join(samples)}")
-        return None
-
-    if dlt_matches:
-        _, load_id = dlt_matches[0]
-        return "dlt", load_id
-    invocation_id = dbt_matches[0][0]
-    return "dbt", invocation_id
-
-
-def _fmt_bytes(n: int | None) -> str:
-    if n is None:
-        return "—"
-    units = ("B", "KB", "MB", "GB", "TB")
-    size = float(n)
-    idx = 0
-    while size >= 1024 and idx < len(units) - 1:
-        size /= 1024
-        idx += 1
-    if idx == 0:
-        return f"{int(size)} {units[idx]}"
-    return f"{size:,.1f} {units[idx]}"
-
-
-def _show_dlt_run(con: duckdb.DuckDBPyConnection, load_id: str) -> None:
-    run = con.execute(
-        """
-        SELECT source_schema, status, inserted_at, schema_version_hash
-        FROM dlt_runs WHERE load_id = ?
-        """,
-        [load_id],
-    ).fetchone()
-    if run is None:
-        error(f"No dlt load found with id '{load_id}'.")
-        raise typer.Exit(1)
-    schema, status, inserted_at, svh = run
-
-    header(f"dlt load: {load_id}")
-    console.print(f"  [bold]Source schema:[/bold] {schema}")
-    console.print(f"  [bold]Status:[/bold] {'[green]success[/green]' if status == 0 else f'[red]error ({status})[/red]'}")
-    console.print(f"  [bold]Loaded at:[/bold] {_fmt_ts(inserted_at)}")
-    if svh:
-        console.print(f"  [bold]Schema version:[/bold] {svh}")
-
-    # Trace enrichment (v0.1.3): the load_id maps back to a transaction_id
-    # via dlt_trace_jobs. When present, surface run duration + bytes.
-    trace_row = con.execute(
-        """
-        SELECT r.transaction_id, r.pipeline_name, r.duration_s, r.success,
-               (SELECT SUM(file_size_bytes) FROM dlt_trace_jobs j
-                WHERE j.transaction_id = r.transaction_id) AS total_bytes
-        FROM dlt_trace_runs r
-        WHERE r.transaction_id IN (
-            SELECT DISTINCT transaction_id FROM dlt_trace_jobs WHERE load_id = ?
-        )
-        LIMIT 1
-        """,
-        [load_id],
-    ).fetchone()
-    if trace_row is not None:
-        txn_id, pipeline_name, duration_s, tr_success, total_bytes = trace_row
-        console.print(f"  [bold]Pipeline:[/bold] {pipeline_name or '—'}")
-        console.print(f"  [bold]Duration:[/bold] {_fmt_duration(duration_s)}")
-        console.print(f"  [bold]Bytes written:[/bold] {_fmt_bytes(total_bytes)}")
-        if not tr_success:
-            console.print("  [bold]Trace:[/bold] [red]contained step exceptions[/red]")
-
-        steps = con.execute(
-            """
-            SELECT step, duration_s, step_exception
-            FROM dlt_trace_steps
-            WHERE transaction_id = ?
-            ORDER BY started_at
-            """,
-            [txn_id],
-        ).fetchall()
-        if steps:
-            steps_table = Table(title="Steps", show_lines=False)
-            steps_table.add_column("Step", style="cyan")
-            steps_table.add_column("Duration", justify="right")
-            steps_table.add_column("Status")
-            for step_name, dur_s, exc in steps:
-                status_str = "[green]ok[/green]" if not exc else "[red]error[/red]"
-                steps_table.add_row(step_name, _fmt_duration(dur_s), status_str)
-            console.print(steps_table)
-
-    tables = con.execute(
-        """
-        SELECT table_name, rows_loaded
-        FROM dlt_rows_by_table
-        WHERE source_schema = ? AND load_id = ?
-        ORDER BY table_name
-        """,
-        [schema, load_id],
-    ).fetchall()
-
-    if not tables:
-        console.print("\n[dim]No per-table row counts captured for this load.[/dim]")
-        return
-
-    # Join per-table row counts with trace job bytes (if available).
-    job_bytes = {
-        row[0]: row[1]
-        for row in con.execute(
-            """
-            SELECT table_name, SUM(file_size_bytes)
-            FROM dlt_trace_jobs
-            WHERE load_id = ?
-            GROUP BY table_name
-            """,
-            [load_id],
-        ).fetchall()
-    }
-
-    table = Table(title="Tables", show_lines=False)
-    table.add_column("Table", style="cyan")
-    table.add_column("Rows", justify="right")
-    if job_bytes:
-        table.add_column("Bytes", justify="right")
-
-    total_rows = 0
-    total_bytes = 0
-    for name, rows_loaded in tables:
-        row_values = [name, f"{rows_loaded:,}"]
-        if job_bytes:
-            b = job_bytes.get(name)
-            row_values.append(_fmt_bytes(b))
-            total_bytes += b or 0
-        table.add_row(*row_values)
-        total_rows += rows_loaded
-
-    totals = ["[bold]Total[/bold]", f"[bold]{total_rows:,}[/bold]"]
-    if job_bytes:
-        totals.append(f"[bold]{_fmt_bytes(total_bytes)}[/bold]")
-    table.add_row(*totals)
-    console.print(table)
-
-
-def _show_dbt_run(con: duckdb.DuckDBPyConnection, invocation_id: str) -> None:
-    run = con.execute(
-        """
-        SELECT command, started_at, elapsed_s, success,
-               models_ok, models_error, tests_passed, tests_failed,
-               dbt_version, target_name
-        FROM dbt_runs WHERE invocation_id = ?
-        """,
-        [invocation_id],
-    ).fetchone()
-    if run is None:
-        error(f"No dbt invocation found with id '{invocation_id}'.")
-        raise typer.Exit(1)
-    (
-        command,
-        started_at,
-        elapsed_s,
-        success,
-        models_ok,
-        models_error,
-        tests_passed,
-        tests_failed,
-        dbt_version,
-        target_name,
-    ) = run
-
-    header(f"dbt {command or 'invocation'}: {invocation_id}")
-    status_str = "[green]success[/green]" if success else "[red]failed[/red]"
-    console.print(f"  [bold]Status:[/bold] {status_str}")
-    console.print(f"  [bold]Started:[/bold] {_fmt_ts(started_at)}")
-    console.print(f"  [bold]Elapsed:[/bold] {_fmt_duration(elapsed_s)}")
-    if target_name:
-        console.print(f"  [bold]Target:[/bold] {target_name}")
-    if dbt_version:
-        console.print(f"  [bold]dbt version:[/bold] {dbt_version}")
-    console.print(
-        f"  [bold]Models:[/bold] {models_ok} ok / {models_error} err   "
-        f"[bold]Tests:[/bold] {tests_passed} pass / {tests_failed} fail"
-    )
-
-    nodes = con.execute(
-        """
-        SELECT node_name, resource_type, status,
-               execution_time_s, rows_affected, message
-        FROM dbt_nodes
-        WHERE invocation_id = ?
-        ORDER BY execution_time_s DESC NULLS LAST, node_name
-        """,
-        [invocation_id],
-    ).fetchall()
-
-    if nodes:
-        table = Table(title="Nodes", show_lines=False)
-        table.add_column("Node", style="cyan", overflow="fold")
-        table.add_column("Type", style="dim")
-        table.add_column("Status")
-        table.add_column("Duration", justify="right")
-        table.add_column("Rows", justify="right")
-        for name, rtype, status, exec_s, rows, _msg in nodes:
-            ok = status in ("success", "pass")
-            status_str = f"[green]{status}[/green]" if ok else f"[red]{status}[/red]"
-            rows_str = f"{rows:,}" if rows is not None else "—"
-            table.add_row(name, rtype or "—", status_str, _fmt_duration(exec_s), rows_str)
-        console.print(table)
-    else:
-        console.print("\n[dim]No node-level detail captured.[/dim]")
-
-    # Schema-diff enrichment (v0.1.3): when a manifest snapshot recorded
-    # changes vs. the previous run, surface them below the nodes table.
-    changes = con.execute(
-        """
-        SELECT change_type, unique_id, column_name, old_value, new_value
-        FROM dbt_schema_changes
-        WHERE invocation_id = ?
-        ORDER BY change_type, unique_id, column_name
-        """,
-        [invocation_id],
-    ).fetchall()
-    if changes:
-        diff_table = Table(title="Schema changes vs. previous run", show_lines=False)
-        diff_table.add_column("Change", style="yellow")
-        diff_table.add_column("Node", style="cyan", overflow="fold")
-        diff_table.add_column("Column", style="dim")
-        diff_table.add_column("Old → New")
-        for change_type, unique_id, column_name, old_value, new_value in changes:
-            old_disp = old_value if old_value is not None else "—"
-            new_disp = new_value if new_value is not None else "—"
-            diff_table.add_row(
-                change_type,
-                unique_id,
-                column_name or "—",
-                f"{old_disp} → {new_disp}",
-            )
-        console.print(diff_table)
-
-
 def _show_run(id_prefix: str) -> None:
     meta = _metadata_or_exit()
-    con = duckdb.connect(str(meta), read_only=True)
+
+    from tycoon.metadata_backends.duckdb_file import DuckDBFileBackend
+
     try:
-        resolved = _resolve_id(con, id_prefix)
-        if resolved is None:
-            error(f"No run matches prefix '{id_prefix}'. Try [bold]tycoon data history[/bold] to list.")
-            raise typer.Exit(1)
-        tool, full_id = resolved
-        if tool == "dlt":
-            _show_dlt_run(con, full_id)
-        else:
-            _show_dbt_run(con, full_id)
-    finally:
-        con.close()
+        with DuckDBFileBackend(meta, read_only=True) as b:
+            repo = HistoryRepository(b)
+            detail = repo.get_run(id_prefix)
+    except Exception:
+        detail = None
+
+    if detail is None:
+        error(
+            f"No run matches prefix '{id_prefix}' (or prefix is ambiguous). "
+            "Try [bold]tycoon data history[/bold] to list."
+        )
+        raise typer.Exit(1)
+
+    s = detail.summary
+    is_dbt = s.runtime_id == "dbt"
+
+    if is_dbt:
+        cmd = s.command or "run"
+        header(f"dbt {cmd}: {s.run_id}")
+    else:
+        header(f"dlt load: {s.run_id}")
+
+    status_str = "[green]success[/green]" if s.status == "success" else "[red]failed[/red]"
+    console.print(f"  [bold]Source:[/bold] {s.source_id}")
+    console.print(f"  [bold]Status:[/bold] {status_str}")
+    console.print(f"  [bold]Started:[/bold] {_fmt_ts(s.started_at)}")
+    console.print(f"  [bold]Duration:[/bold] {_fmt_duration(s.duration_seconds)}")
+
+    if detail.error:
+        console.print(f"  [bold]Error:[/bold] [red]{detail.error}[/red]")
+
+    if detail.rows_by_table:
+        rows_table = Table(title="Tables", show_lines=False)
+        rows_table.add_column("Table", style="cyan")
+        rows_table.add_column("Rows", justify="right")
+        total = 0
+        for tname, rcount in sorted(detail.rows_by_table.items()):
+            rows_table.add_row(tname, f"{rcount:,}")
+            total += rcount
+        rows_table.add_row("[bold]Total[/bold]", f"[bold]{total:,}[/bold]")
+        console.print(rows_table)
+    elif not detail.error:
+        console.print("\n[dim]No per-table detail captured for this run.[/dim]")
 
 
 # ---------------------------------------------------------------------------
@@ -640,10 +273,9 @@ def history_default(
         "--source",
         "-s",
         help=(
-            "Filter dlt runs to a specific source. Accepts either the "
-            "config name from tycoon.yml (e.g. 'pokeapi') or the raw "
-            "schema literal (e.g. 'raw_pokeapi'). dbt runs are hidden "
-            "when this flag is set since they aren't source-scoped."
+            "Filter dlt runs to a specific source. Accepts the config name "
+            "from tycoon.yml (e.g. 'pokeapi') or a literal source id. "
+            "dbt runs are hidden when this flag is set."
         ),
     ),
     layer: str = typer.Option(
@@ -653,8 +285,8 @@ def history_default(
         help=(
             "Filter dbt invocations to those that touched at least one "
             "model in the given layer: staging / intermediate / mart / "
-            "snapshot / seed. Suppresses dlt rows since they aren't "
-            "layer-classified. Requires a compiled dbt manifest."
+            "snapshot / seed. Suppresses dlt rows. Requires a compiled "
+            "dbt manifest."
         ),
     ),
 ) -> None:
@@ -673,8 +305,8 @@ def history_default(
 @app.command("show")
 def history_show(
     run_id: str = typer.Argument(
-        ..., help="Invocation id (dbt) or load id (dlt). Short prefix OK."
+        ..., help="Load id (dlt) or event id (dbt). Short prefix OK."
     ),
 ) -> None:
-    """Show per-node / per-table detail for a specific run."""
+    """Show per-table detail for a specific run."""
     _show_run(run_id)

--- a/src/tycoon/commands/status.py
+++ b/src/tycoon/commands/status.py
@@ -70,7 +70,7 @@ def _sources_from_backend(metadata_db: Path) -> dict[str, dict]:
             if existing is None or e.timestamp > existing["last_sync"]:
                 result[e.source_id] = {
                     "last_sync": e.timestamp,
-                    "rows": dict(e.rows_loaded),
+                    "rows": dict(e.rows_loaded or {}),
                 }
         return result
     except Exception:

--- a/src/tycoon/commands/status.py
+++ b/src/tycoon/commands/status.py
@@ -22,7 +22,6 @@ import datetime
 from pathlib import Path
 from typing import Iterable, Optional
 
-import duckdb
 import typer
 from rich.panel import Panel
 from rich.table import Table
@@ -43,48 +42,45 @@ from tycoon.project import TransformationTool
 from tycoon.utils.console import console, error, header, info, warn
 
 
-# -- Freshness helpers (preserved from v0.1.6) ----------------------------------
+# -- Freshness helpers ---------------------------------------------------------
 
 
-def _query_last_sync(raw_db: Path, schema: str) -> Optional[datetime.datetime]:
-    """Return the timestamp of the last successful dlt load for a schema."""
+def _sources_from_backend(metadata_db: Path) -> dict[str, dict]:
+    """Read per-source last-sync and row counts from the events backend.
+
+    Returns ``{source_id: {"last_sync": datetime, "rows": {table: count}}}``.
+    Falls back to an empty dict on any failure (missing file, missing table,
+    legacy schema without an events table).
+    """
+    if not metadata_db.exists():
+        return {}
     try:
-        con = duckdb.connect(str(raw_db), read_only=True)
-        row = con.execute(
-            f"SELECT max(inserted_at) FROM {schema}._dlt_loads WHERE status = 0"
-        ).fetchone()
-        con.close()
-        if row and row[0]:
-            val = row[0]
-            if isinstance(val, datetime.datetime):
-                return val
-            return datetime.datetime.fromisoformat(str(val))
-    except Exception:
-        pass
-    return None
+        from tycoon.core.events import RunCompleted
+        from tycoon.core.metadata import EventFilter
+        from tycoon.metadata_backends.duckdb_file import DuckDBFileBackend
 
+        with DuckDBFileBackend(metadata_db, read_only=True) as b:
+            events = b.query_events(EventFilter(event_type="run_completed"))
 
-def _query_row_counts(raw_db: Path, schema: str) -> dict[str, int]:
-    """Return {table: row_count} for all user tables in a schema."""
-    counts: dict[str, int] = {}
-    try:
-        con = duckdb.connect(str(raw_db), read_only=True)
-        tables = con.execute(
-            "SELECT table_name FROM information_schema.tables "
-            "WHERE table_schema = ? AND table_name NOT LIKE '_dlt_%'",
-            [schema],
-        ).fetchall()
-        for (table,) in tables:
-            row = con.execute(f'SELECT count(*) FROM "{schema}"."{table}"').fetchone()
-            counts[table] = row[0] if row else 0
-        con.close()
+        result: dict[str, dict] = {}
+        for e in events:
+            if not isinstance(e, RunCompleted):
+                continue
+            existing = result.get(e.source_id)
+            if existing is None or e.timestamp > existing["last_sync"]:
+                result[e.source_id] = {
+                    "last_sync": e.timestamp,
+                    "rows": dict(e.rows_loaded),
+                }
+        return result
     except Exception:
-        pass
-    return counts
+        return {}
 
 
 def _query_run_counts(metadata_db: Path) -> dict[str, int]:
     """Return {source_schema: run_count} from the observability metadata DB."""
+    import duckdb
+
     if not metadata_db.exists():
         return {}
     try:
@@ -127,6 +123,8 @@ def _query_layer_last_build(
     metadata_db: Path, model_names: list[str]
 ) -> Optional[datetime.datetime]:
     """Latest successful build start time across ``model_names``."""
+    import duckdb
+
     if not model_names or not metadata_db.exists():
         return None
     try:
@@ -149,7 +147,10 @@ def _query_layer_last_build(
 
 
 def _render_sources_panel(
-    sources: list[LayerClassification], *, raw_db: Path, run_counts: dict[str, int]
+    sources: list[LayerClassification],
+    *,
+    metadata_db: Path,
+    run_counts: dict[str, int],
 ) -> None:
     """The unified Sources panel: dlt + Fivetran rows side by side."""
     console.print()
@@ -162,7 +163,7 @@ def _render_sources_panel(
         )
         return
 
-    db_exists = raw_db.exists()
+    sources_data = _sources_from_backend(metadata_db)
 
     table = Table(show_lines=False)
     table.add_column("Source", style="bold cyan")
@@ -177,9 +178,10 @@ def _render_sources_panel(
     for src in sources:
         schema = src.schema or "—"
 
-        if src.vendor is Vendor.DLT and db_exists and src.schema:
-            last_sync = _query_last_sync(raw_db, src.schema)
-            row_counts = _query_row_counts(raw_db, src.schema)
+        if src.vendor is Vendor.DLT and src.schema:
+            data = sources_data.get(src.name, {})
+            last_sync = data.get("last_sync")
+            row_counts = data.get("rows", {})
             runs = run_counts.get(src.schema, 0)
             sync_str = last_sync.strftime("%Y-%m-%d %H:%M") if last_sync else "—"
             fresh_label, fresh_style = _freshness_label(last_sync)
@@ -358,9 +360,10 @@ def status_cmd() -> None:
         )
 
     all_sources = [*dlt_sources, *fivetran_sources]
-    run_counts = _query_run_counts(metadata_db_path(config.root))
+    _meta_db = metadata_db_path(config.root)
+    run_counts = _query_run_counts(_meta_db)
     _render_sources_panel(
-        all_sources, raw_db=config.raw_db, run_counts=run_counts
+        all_sources, metadata_db=_meta_db, run_counts=run_counts
     )
     if fivetran_managed:
         _render_fivetran_detail()

--- a/src/tycoon/commands/transform.py
+++ b/src/tycoon/commands/transform.py
@@ -87,9 +87,10 @@ def _capture_dbt_and_refresh_safe(dbt_cmd: str) -> None:
         with open(run_results_path) as f:
             run_results = json.load(f)
 
-        elapsed = float(run_results.get("elapsed_time", 0.0))
-        target = run_results.get("args", {}).get("target", "dev") or "dev"
-        results = run_results.get("results", [])
+        elapsed = float(run_results.get("elapsed_time") or 0.0)
+        args = run_results.get("args") or {}
+        target = args.get("target", "dev") or "dev"
+        results = run_results.get("results") or []
         models_run = len(results)
         models_errored = sum(
             1 for r in results if r.get("status") not in ("success", "pass", "warn")

--- a/src/tycoon/commands/transform.py
+++ b/src/tycoon/commands/transform.py
@@ -73,6 +73,44 @@ def _capture_dbt_and_refresh_safe(dbt_cmd: str) -> None:
     except Exception:
         pass
 
+    try:
+        import json
+
+        from tycoon.core.events import DbtRunCompleted
+        from tycoon.metadata_backends.duckdb_file import DuckDBFileBackend
+        from tycoon.observability import metadata_db_path
+
+        run_results_path = config.dbt_project_dir / "target" / "run_results.json"
+        if not run_results_path.exists():
+            return
+
+        with open(run_results_path) as f:
+            run_results = json.load(f)
+
+        elapsed = float(run_results.get("elapsed_time", 0.0))
+        target = run_results.get("args", {}).get("target", "dev") or "dev"
+        results = run_results.get("results", [])
+        models_run = len(results)
+        models_errored = sum(
+            1 for r in results if r.get("status") not in ("success", "pass", "warn")
+        )
+        models_passed = models_run - models_errored
+
+        event = DbtRunCompleted(
+            source_id="dbt",
+            runtime_id="dbt",
+            command=dbt_cmd,
+            target=target,
+            models_run=models_run,
+            models_passed=models_passed,
+            models_errored=models_errored,
+            duration_seconds=elapsed,
+        )
+        with DuckDBFileBackend(metadata_db_path(config.root)) as b:
+            b.append_event(event)
+    except Exception:
+        pass
+
 
 def _auto_osi_scaffold_safe() -> None:
     """Re-emit dbt_project/semantic/osi.yaml after a successful dbt run.

--- a/src/tycoon/core/history.py
+++ b/src/tycoon/core/history.py
@@ -31,7 +31,7 @@ class HistoryRepository:
     def __init__(self, backend: MetadataBackend) -> None:
         self._backend = backend
 
-    def list_runs(self, limit: int = 20) -> list[RunSummary]:
+    def list_runs(self, limit: int | None = 20) -> list[RunSummary]:
         events = self._backend.query_events()
         summaries: list[RunSummary] = []
         for e in events:
@@ -43,7 +43,7 @@ class HistoryRepository:
                     status="success",
                     started_at=e.timestamp,
                     duration_seconds=e.duration_seconds,
-                    rows_total=sum(e.rows_loaded.values()),
+                    rows_total=sum((e.rows_loaded or {}).values()),
                 ))
             elif isinstance(e, RunFailed):
                 summaries.append(RunSummary(
@@ -67,7 +67,9 @@ class HistoryRepository:
                     command=e.command,
                 ))
         summaries.sort(key=lambda s: s.started_at, reverse=True)
-        return summaries[:limit]
+        if limit is not None:
+            return summaries[:limit]
+        return summaries
 
     def get_run(self, run_id_prefix: str) -> RunDetail | None:
         events = self._backend.query_events()
@@ -84,7 +86,7 @@ class HistoryRepository:
                         status="success",
                         started_at=e.timestamp,
                         duration_seconds=e.duration_seconds,
-                        rows_total=sum(e.rows_loaded.values()),
+                        rows_total=sum((e.rows_loaded or {}).values()),
                     ), e))
             elif isinstance(e, RunFailed):
                 if e.event_id.startswith(run_id_prefix):
@@ -118,8 +120,8 @@ class HistoryRepository:
         if isinstance(event, RunCompleted):
             return RunDetail(
                 summary=summary,
-                rows_by_table=event.rows_loaded,
-                tables_created=event.tables_created,
+                rows_by_table=event.rows_loaded or {},
+                tables_created=event.tables_created or [],
                 error=None,
             )
         if isinstance(event, RunFailed):

--- a/src/tycoon/core/history.py
+++ b/src/tycoon/core/history.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 
 from tycoon.core.events import DbtRunCompleted, RunCompleted, RunFailed

--- a/src/tycoon/core/history.py
+++ b/src/tycoon/core/history.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from tycoon.core.events import DbtRunCompleted, RunCompleted, RunFailed
+from tycoon.core.metadata import MetadataBackend
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    run_id: str
+    source_id: str
+    runtime_id: str
+    status: str
+    started_at: datetime
+    duration_seconds: float
+    rows_total: int
+    command: str | None = None
+
+
+@dataclass(frozen=True)
+class RunDetail:
+    summary: RunSummary
+    rows_by_table: dict[str, int]
+    tables_created: list[str]
+    error: str | None
+
+
+class HistoryRepository:
+    def __init__(self, backend: MetadataBackend) -> None:
+        self._backend = backend
+
+    def list_runs(self, limit: int = 20) -> list[RunSummary]:
+        events = self._backend.query_events()
+        summaries: list[RunSummary] = []
+        for e in events:
+            if isinstance(e, RunCompleted):
+                summaries.append(RunSummary(
+                    run_id=e.load_id or e.event_id,
+                    source_id=e.source_id,
+                    runtime_id=e.runtime_id,
+                    status="success",
+                    started_at=e.timestamp,
+                    duration_seconds=e.duration_seconds,
+                    rows_total=sum(e.rows_loaded.values()),
+                ))
+            elif isinstance(e, RunFailed):
+                summaries.append(RunSummary(
+                    run_id=e.event_id,
+                    source_id=e.source_id,
+                    runtime_id=e.runtime_id,
+                    status="failed",
+                    started_at=e.timestamp,
+                    duration_seconds=0.0,
+                    rows_total=0,
+                ))
+            elif isinstance(e, DbtRunCompleted):
+                summaries.append(RunSummary(
+                    run_id=e.event_id,
+                    source_id=e.source_id,
+                    runtime_id=e.runtime_id,
+                    status="success" if e.models_errored == 0 else "failed",
+                    started_at=e.timestamp,
+                    duration_seconds=e.duration_seconds,
+                    rows_total=e.models_run,
+                    command=e.command,
+                ))
+        summaries.sort(key=lambda s: s.started_at, reverse=True)
+        return summaries[:limit]
+
+    def get_run(self, run_id_prefix: str) -> RunDetail | None:
+        events = self._backend.query_events()
+        matches: list[tuple[RunSummary, object]] = []
+
+        for e in events:
+            if isinstance(e, RunCompleted):
+                eid = e.load_id or e.event_id
+                if eid.startswith(run_id_prefix):
+                    matches.append((RunSummary(
+                        run_id=eid,
+                        source_id=e.source_id,
+                        runtime_id=e.runtime_id,
+                        status="success",
+                        started_at=e.timestamp,
+                        duration_seconds=e.duration_seconds,
+                        rows_total=sum(e.rows_loaded.values()),
+                    ), e))
+            elif isinstance(e, RunFailed):
+                if e.event_id.startswith(run_id_prefix):
+                    matches.append((RunSummary(
+                        run_id=e.event_id,
+                        source_id=e.source_id,
+                        runtime_id=e.runtime_id,
+                        status="failed",
+                        started_at=e.timestamp,
+                        duration_seconds=0.0,
+                        rows_total=0,
+                    ), e))
+            elif isinstance(e, DbtRunCompleted):
+                if e.event_id.startswith(run_id_prefix):
+                    matches.append((RunSummary(
+                        run_id=e.event_id,
+                        source_id=e.source_id,
+                        runtime_id=e.runtime_id,
+                        status="success" if e.models_errored == 0 else "failed",
+                        started_at=e.timestamp,
+                        duration_seconds=e.duration_seconds,
+                        rows_total=e.models_run,
+                        command=e.command,
+                    ), e))
+
+        if len(matches) != 1:
+            return None
+
+        summary, event = matches[0]
+
+        if isinstance(event, RunCompleted):
+            return RunDetail(
+                summary=summary,
+                rows_by_table=event.rows_loaded,
+                tables_created=event.tables_created,
+                error=None,
+            )
+        if isinstance(event, RunFailed):
+            return RunDetail(
+                summary=summary,
+                rows_by_table={},
+                tables_created=[],
+                error=event.error,
+            )
+        if isinstance(event, DbtRunCompleted):
+            return RunDetail(
+                summary=summary,
+                rows_by_table={},
+                tables_created=[],
+                error=None,
+            )
+        return None

--- a/src/tycoon/ingestion/runner.py
+++ b/src/tycoon/ingestion/runner.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 
 import re
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
 import dlt
+
+from tycoon.core.events import RunCompleted, RunFailed, RunStarted
 
 from tycoon.ingestion.catalog import CATALOG
 from tycoon.ingestion.source_manager import SOURCES_DIR, get_run_module_path, is_source_installed
@@ -170,6 +173,40 @@ def _build_filesystem_source(source_config: SourceConfig) -> Any:
     return files
 
 
+def _emit_event_safe(metadata_db: Path | None, event: Any) -> None:
+    """Append an event to the metadata backend; silently no-ops on any failure."""
+    if metadata_db is None:
+        return
+    try:
+        from tycoon.metadata_backends.duckdb_file import DuckDBFileBackend
+
+        with DuckDBFileBackend(metadata_db) as b:
+            b.append_event(event)
+    except Exception:
+        pass
+
+
+def _build_run_completed(name: str, load_info: Any, elapsed: float) -> RunCompleted:
+    """Build a RunCompleted event from dlt load_info."""
+    rows_by_table: dict[str, int] = {}
+    for pkg in getattr(load_info, "load_packages", []) or []:
+        for job in getattr(pkg, "jobs", []) or []:
+            if getattr(job, "job_state", None) == "completed":
+                tname = getattr(job, "table_name", "")
+                if tname and not tname.startswith("_"):
+                    rows_by_table[tname] = rows_by_table.get(tname, 0) + (getattr(job, "rows_count", 0) or 0)
+    loads_ids = getattr(load_info, "loads_ids", []) or []
+    return RunCompleted(
+        source_id=name,
+        runtime_id="dlt-managed",
+        load_id=loads_ids[0] if loads_ids else "",
+        duration_seconds=round(elapsed, 2),
+        rows_loaded=rows_by_table,
+        tables_created=list(rows_by_table),
+        tables_updated=[],
+    )
+
+
 def _capture_and_refresh_safe(
     raw_db_path: Path,
     pipeline: dlt.Pipeline | None = None,
@@ -234,56 +271,73 @@ def run_source(
 
     Returns (pipeline, load_info).
     """
-    # 1. Legacy pipeline delegation (keyed by source name)
-    if name in _LEGACY_PIPELINES:
-        pipeline, load_info = _run_legacy(
-            name, raw_db_path=raw_db_path, max_records=max_records, **kwargs
+    _started = time.monotonic()
+
+    _metadata_db: Path | None = None
+    try:
+        from tycoon.config import config as _cfg
+        _metadata_db = _cfg.root / ".tycoon" / "metadata.duckdb"
+    except Exception:
+        pass
+
+    _emit_event_safe(_metadata_db, RunStarted(source_id=name, runtime_id="dlt-managed"))
+
+    try:
+        # 1. Legacy pipeline delegation (keyed by source name)
+        if name in _LEGACY_PIPELINES:
+            pipeline, load_info = _run_legacy(
+                name, raw_db_path=raw_db_path, max_records=max_records, **kwargs
+            )
+            _capture_and_refresh_safe(raw_db_path, pipeline=pipeline)
+            _emit_event_safe(_metadata_db, _build_run_completed(name, load_info, time.monotonic() - _started))
+            return pipeline, load_info
+
+        # 2. Native builders win over the catalog path. These types ship with
+        #    dlt core and don't need an `~/.tycoon/sources/<type>/` install.
+        source_type = source_config.type
+        if source_type not in _NATIVE_BUILDERS and source_type in CATALOG:
+            # 3. Catalog source dispatch — load from ~/.tycoon/sources/
+            pipeline, load_info = _run_catalog(
+                source_type, name, source_config, raw_db_path, max_records
+            )
+            _capture_and_refresh_safe(raw_db_path, pipeline=pipeline)
+            _emit_event_safe(_metadata_db, _build_run_completed(name, load_info, time.monotonic() - _started))
+            return pipeline, load_info
+
+        # Generic pipeline
+        pipeline = dlt.pipeline(
+            pipeline_name=name,
+            destination=dlt.destinations.duckdb(str(raw_db_path)),
+            dataset_name=source_config.schema_name,
         )
+
+        builder = _NATIVE_BUILDERS.get(source_type)
+        if builder is None:
+            # Try dynamic import: dlt.sources.<source_type>
+            try:
+                import importlib
+
+                mod = importlib.import_module(f"dlt.sources.{source_type}")
+                source_fn = getattr(mod, source_type, None)
+                if source_fn is None:
+                    raise ImportError(f"No callable '{source_type}' in dlt.sources.{source_type}")
+                dlt_source = source_fn(**source_config.config)
+            except ImportError as exc:
+                raise RuntimeError(
+                    f"Unknown source type '{source_type}'. "
+                    f"Install with: tycoon sources add {source_type}"
+                ) from exc
+        else:
+            dlt_source = builder(source_config)
+
+        load_info = pipeline.run(dlt_source)
         _capture_and_refresh_safe(raw_db_path, pipeline=pipeline)
+        _emit_event_safe(_metadata_db, _build_run_completed(name, load_info, time.monotonic() - _started))
         return pipeline, load_info
 
-    # 2. Native builders win over the catalog path. These types ship with
-    #    dlt core and don't need an `~/.tycoon/sources/<type>/` install.
-    source_type = source_config.type
-    if source_type not in _NATIVE_BUILDERS and source_type in CATALOG:
-        # 3. Catalog source dispatch — load from ~/.tycoon/sources/
-        pipeline, load_info = _run_catalog(
-            source_type, name, source_config, raw_db_path, max_records
-        )
-        _capture_and_refresh_safe(raw_db_path, pipeline=pipeline)
-        return pipeline, load_info
-
-    # Generic pipeline
-    pipeline = dlt.pipeline(
-        pipeline_name=name,
-        destination=dlt.destinations.duckdb(str(raw_db_path)),
-        dataset_name=source_config.schema_name,
-    )
-
-    builders = _NATIVE_BUILDERS
-
-    builder = builders.get(source_type)
-    if builder is None:
-        # Try dynamic import: dlt.sources.<source_type>
-        try:
-            import importlib
-
-            mod = importlib.import_module(f"dlt.sources.{source_type}")
-            source_fn = getattr(mod, source_type, None)
-            if source_fn is None:
-                raise ImportError(f"No callable '{source_type}' in dlt.sources.{source_type}")
-            dlt_source = source_fn(**source_config.config)
-        except ImportError as exc:
-            raise RuntimeError(
-                f"Unknown source type '{source_type}'. "
-                f"Install with: tycoon sources add {source_type}"
-            ) from exc
-    else:
-        dlt_source = builder(source_config)
-
-    load_info = pipeline.run(dlt_source)
-    _capture_and_refresh_safe(raw_db_path, pipeline=pipeline)
-    return pipeline, load_info
+    except Exception as exc:
+        _emit_event_safe(_metadata_db, RunFailed(source_id=name, runtime_id="dlt-managed", error=str(exc)))
+        raise
 
 
 def _run_legacy(

--- a/src/tycoon/ingestion/runner.py
+++ b/src/tycoon/ingestion/runner.py
@@ -186,15 +186,16 @@ def _emit_event_safe(metadata_db: Path | None, event: Any) -> None:
         pass
 
 
-def _build_run_completed(name: str, load_info: Any, elapsed: float) -> RunCompleted:
-    """Build a RunCompleted event from dlt load_info."""
+def _build_run_completed(name: str, pipeline: Any, load_info: Any, elapsed: float) -> RunCompleted:
+    """Build a RunCompleted event from dlt pipeline trace + load_info."""
     rows_by_table: dict[str, int] = {}
-    for pkg in getattr(load_info, "load_packages", []) or []:
-        for job in getattr(pkg, "jobs", []) or []:
-            if getattr(job, "job_state", None) == "completed":
-                tname = getattr(job, "table_name", "")
-                if tname and not tname.startswith("_"):
-                    rows_by_table[tname] = rows_by_table.get(tname, 0) + (getattr(job, "rows_count", 0) or 0)
+    try:
+        ni = pipeline.last_trace.last_normalize_info
+        rows_by_table = {
+            t: c for t, c in (ni.row_counts or {}).items() if not t.startswith("_")
+        }
+    except Exception:
+        pass
     loads_ids = getattr(load_info, "loads_ids", []) or []
     return RunCompleted(
         source_id=name,
@@ -289,7 +290,7 @@ def run_source(
                 name, raw_db_path=raw_db_path, max_records=max_records, **kwargs
             )
             _capture_and_refresh_safe(raw_db_path, pipeline=pipeline)
-            _emit_event_safe(_metadata_db, _build_run_completed(name, load_info, time.monotonic() - _started))
+            _emit_event_safe(_metadata_db, _build_run_completed(name, pipeline, load_info, time.monotonic() - _started))
             return pipeline, load_info
 
         # 2. Native builders win over the catalog path. These types ship with
@@ -301,7 +302,7 @@ def run_source(
                 source_type, name, source_config, raw_db_path, max_records
             )
             _capture_and_refresh_safe(raw_db_path, pipeline=pipeline)
-            _emit_event_safe(_metadata_db, _build_run_completed(name, load_info, time.monotonic() - _started))
+            _emit_event_safe(_metadata_db, _build_run_completed(name, pipeline, load_info, time.monotonic() - _started))
             return pipeline, load_info
 
         # Generic pipeline
@@ -332,7 +333,7 @@ def run_source(
 
         load_info = pipeline.run(dlt_source)
         _capture_and_refresh_safe(raw_db_path, pipeline=pipeline)
-        _emit_event_safe(_metadata_db, _build_run_completed(name, load_info, time.monotonic() - _started))
+        _emit_event_safe(_metadata_db, _build_run_completed(name, pipeline, load_info, time.monotonic() - _started))
         return pipeline, load_info
 
     except Exception as exc:

--- a/src/tycoon/ingestion/runner.py
+++ b/src/tycoon/ingestion/runner.py
@@ -186,13 +186,17 @@ def _emit_event_safe(metadata_db: Path | None, event: Any) -> None:
         pass
 
 
+_DLT_INTERNAL_TABLES = frozenset({"_dlt_pipeline_state", "_dlt_loads", "_dlt_version"})
+
+
 def _build_run_completed(name: str, pipeline: Any, load_info: Any, elapsed: float) -> RunCompleted:
     """Build a RunCompleted event from dlt pipeline trace + load_info."""
     rows_by_table: dict[str, int] = {}
     try:
         ni = pipeline.last_trace.last_normalize_info
         rows_by_table = {
-            t: c for t, c in (ni.row_counts or {}).items() if not t.startswith("_")
+            t: c for t, c in (ni.row_counts or {}).items()
+            if t not in _DLT_INTERNAL_TABLES
         }
     except Exception:
         pass

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -9,7 +9,7 @@ import duckdb
 import pytest
 
 from tycoon.cli import app
-from tycoon.core.events import DbtRunCompleted, RunCompleted, RunFailed
+from tycoon.core.events import DbtRunCompleted, RunCompleted
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -9,10 +9,11 @@ import duckdb
 import pytest
 
 from tycoon.cli import app
+from tycoon.core.events import DbtRunCompleted, RunCompleted, RunFailed
 
 
 # ---------------------------------------------------------------------------
-# Fixture: a tmp project with a seeded metadata.duckdb
+# Fixtures and seeding helpers
 # ---------------------------------------------------------------------------
 
 
@@ -44,16 +45,10 @@ def _seed_metadata(
     dbt_runs: list[tuple] | None = None,
     dbt_nodes: list[tuple] | None = None,
 ) -> Path:
-    """Seed .tycoon/metadata.duckdb with explicit rows.
+    """Seed .tycoon/metadata.duckdb with rows in the OLD observability schema.
 
-    Tuple shapes (all trailing captured_at is auto-filled with now()):
-      dlt_runs: (source_schema, load_id, status, inserted_at, svh)
-      dlt_rows: (source_schema, table_name, load_id, rows_loaded)
-      dbt_runs: (invocation_id, command, started_at, elapsed_s, success,
-                 models_ok, models_error, tests_passed, tests_failed,
-                 dbt_version, target_name)
-      dbt_nodes: (invocation_id, node_name, resource_type, status,
-                  execution_time_s, rows_affected, compile_time_s, message)
+    Used only by TestStatusRunsColumn, which still reads ``dlt_runs`` via
+    ``_query_run_counts()``. All history tests use ``_seed_events()`` instead.
     """
     from tycoon.observability import ensure_schema, metadata_db_path
 
@@ -87,6 +82,17 @@ def _seed_metadata(
     return meta
 
 
+def _seed_events(root: Path, events: list) -> Path:
+    """Seed .tycoon/metadata.duckdb with events via the new backend."""
+    from tycoon.metadata_backends.duckdb_file import DuckDBFileBackend
+
+    meta = root / ".tycoon" / "metadata.duckdb"
+    with DuckDBFileBackend(meta) as b:
+        for e in events:
+            b.append_event(e)
+    return meta
+
+
 @pytest.fixture
 def history_project(tmp_path: Path, monkeypatch):
     """Write tycoon.yml + seed metadata, then monkeypatch the history module's config."""
@@ -116,39 +122,39 @@ class TestHistoryList:
         assert "No run history yet" in result.stdout
 
     def test_lists_dlt_runs(self, history_project, cli_runner):
-        _seed_metadata(
+        _seed_events(
             history_project,
-            dlt_runs=[
-                ("raw_src_a", "load-aaaaaaaa-001", 0, datetime(2026, 4, 19, 15, 30), "hash-v1"),
-            ],
-            dlt_rows=[
-                ("raw_src_a", "items", "load-aaaaaaaa-001", 100),
-                ("raw_src_a", "orders", "load-aaaaaaaa-001", 50),
+            [
+                RunCompleted(
+                    source_id="raw_src_a",
+                    runtime_id="dlt-managed",
+                    load_id="load-aaaaaaaa-001",
+                    rows_loaded={"items": 100, "orders": 50},
+                    timestamp=datetime(2026, 4, 19, 15, 30, tzinfo=timezone.utc),
+                ),
             ],
         )
         result = cli_runner.invoke(app, ["data", "history"])
         assert result.exit_code == 0
         assert "dlt" in result.stdout
         assert "raw_src_a" in result.stdout
-        # total rows summary: 150
         assert "150" in result.stdout
 
     def test_lists_dbt_runs(self, history_project, cli_runner):
-        _seed_metadata(
+        _seed_events(
             history_project,
-            dbt_runs=[
-                (
-                    "inv-abcdefgh",
-                    "build",
-                    datetime(2026, 4, 19, 16, 0),
-                    38.1,
-                    True,
-                    12,
-                    0,
-                    45,
-                    0,
-                    "1.9.0",
-                    "dev",
+            [
+                DbtRunCompleted(
+                    event_id="inv-abcdefgh",
+                    source_id="dbt",
+                    runtime_id="dbt",
+                    command="build",
+                    target="dev",
+                    models_run=12,
+                    models_passed=12,
+                    models_errored=0,
+                    duration_seconds=38.1,
+                    timestamp=datetime(2026, 4, 19, 16, 0, tzinfo=timezone.utc),
                 ),
             ],
         )
@@ -156,35 +162,31 @@ class TestHistoryList:
         assert result.exit_code == 0
         assert "dbt" in result.stdout
         assert "build" in result.stdout
-        # short id prefix appears in the ref column
         assert "inv-abcd" in result.stdout
 
     def test_filters_by_tool_dlt(self, history_project, cli_runner):
-        _seed_metadata(
+        _seed_events(
             history_project,
-            dlt_runs=[
-                ("s", "load-1", 0, datetime(2026, 4, 19, 10, 0), "h"),
-            ],
-            dbt_runs=[
-                (
-                    "inv-1",
-                    "run",
-                    datetime(2026, 4, 19, 11, 0),
-                    1.0,
-                    True,
-                    0,
-                    0,
-                    0,
-                    0,
-                    "1.9.0",
-                    "dev",
+            [
+                RunCompleted(
+                    source_id="s",
+                    runtime_id="dlt-managed",
+                    load_id="load-1",
+                    timestamp=datetime(2026, 4, 19, 10, 0, tzinfo=timezone.utc),
+                ),
+                DbtRunCompleted(
+                    event_id="inv-1",
+                    source_id="dbt",
+                    runtime_id="dbt",
+                    command="run",
+                    target="dev",
+                    timestamp=datetime(2026, 4, 19, 11, 0, tzinfo=timezone.utc),
                 ),
             ],
         )
         result = cli_runner.invoke(app, ["data", "history", "--tool", "dlt"])
         assert result.exit_code == 0
-        # Only dlt should appear as a tool cell — "dbt" will still appear in the
-        # command hint text. Check for the invocation id instead.
+        # dbt invocation should be absent when filtering to dlt only
         assert "inv-1" not in result.stdout
 
     def test_invalid_tool_rejected(self, history_project, cli_runner):
@@ -195,11 +197,16 @@ class TestHistoryList:
         # Use prefixes that differ in the first 8 chars since the ref column
         # truncates load_ids to 8.
         prefixes = ["aardvark", "badger01", "cheetah0", "dolphin0", "eagle-01"]
-        rows = [
-            ("s", f"{p}-{i:03d}", 0, datetime(2026, 4, 19, 10, i), "h")
+        events = [
+            RunCompleted(
+                source_id="s",
+                runtime_id="dlt-managed",
+                load_id=f"{p}-{i:03d}",
+                timestamp=datetime(2026, 4, 19, 10, i, tzinfo=timezone.utc),
+            )
             for i, p in enumerate(prefixes)
         ]
-        _seed_metadata(history_project, dlt_runs=rows)
+        _seed_events(history_project, events)
         result = cli_runner.invoke(app, ["data", "history", "--limit", "2"])
         assert result.exit_code == 0
         # Only the two newest (eagle, dolphin) should appear
@@ -209,14 +216,24 @@ class TestHistoryList:
 
 
 class TestHistorySourceFilter:
-    """`--source` filters dlt runs by schema; hides dbt runs entirely."""
+    """`--source` filters dlt runs by source_id; hides dbt runs entirely."""
 
     def test_source_filters_dlt_by_schema_literal(self, history_project, cli_runner):
-        _seed_metadata(
+        _seed_events(
             history_project,
-            dlt_runs=[
-                ("raw_apples", "apple-load-1", 0, datetime(2026, 4, 19, 10, 0), "h"),
-                ("raw_bananas", "banana-load-1", 0, datetime(2026, 4, 19, 11, 0), "h"),
+            [
+                RunCompleted(
+                    source_id="raw_apples",
+                    runtime_id="dlt-managed",
+                    load_id="apple-load-1",
+                    timestamp=datetime(2026, 4, 19, 10, 0, tzinfo=timezone.utc),
+                ),
+                RunCompleted(
+                    source_id="raw_bananas",
+                    runtime_id="dlt-managed",
+                    load_id="banana-load-1",
+                    timestamp=datetime(2026, 4, 19, 11, 0, tzinfo=timezone.utc),
+                ),
             ],
         )
         result = cli_runner.invoke(
@@ -228,7 +245,7 @@ class TestHistorySourceFilter:
         assert "banana-l" not in result.stdout
 
     def test_source_resolves_config_name_to_schema(self, history_project, cli_runner, monkeypatch):
-        # Set up tycoon.yml with a named source whose schema differs from its name
+        # Set up tycoon.yml with a named source
         yml = (
             "name: test\n"
             "version: 0.1.0\n"
@@ -242,40 +259,51 @@ class TestHistorySourceFilter:
         )
         (history_project / "tycoon.yml").write_text(yml)
 
-        # Rebind the history command's config to pick up the updated yml
         from tycoon.commands import history as history_mod
         from tycoon.config import TycoonConfig
 
         monkeypatch.setattr(history_mod, "config", TycoonConfig(project_root=history_project))
 
-        _seed_metadata(
+        _seed_events(
             history_project,
-            dlt_runs=[
-                ("raw_pokeapi", "poke-load-1", 0, datetime(2026, 4, 19, 10, 0), "h"),
-                ("raw_other", "other-load-1", 0, datetime(2026, 4, 19, 11, 0), "h"),
+            [
+                RunCompleted(
+                    source_id="pokeapi",
+                    runtime_id="dlt-managed",
+                    load_id="poke-load-1",
+                    timestamp=datetime(2026, 4, 19, 10, 0, tzinfo=timezone.utc),
+                ),
+                RunCompleted(
+                    source_id="other",
+                    runtime_id="dlt-managed",
+                    load_id="other-load-1",
+                    timestamp=datetime(2026, 4, 19, 11, 0, tzinfo=timezone.utc),
+                ),
             ],
         )
-        # Pass the config name 'pokeapi' — should be resolved to schema 'raw_pokeapi'
+        # Events are keyed by source_id = config name (not schema)
         result = cli_runner.invoke(app, ["data", "history", "--source", "pokeapi"])
         assert result.exit_code == 0
-        # The resolved schema should appear in the title; the other schema should not
-        assert "raw_pokeapi" in result.stdout
+        assert "pokeapi" in result.stdout
         assert "raw_other" not in result.stdout
 
     def test_source_hides_dbt_runs(self, history_project, cli_runner):
-        _seed_metadata(
+        _seed_events(
             history_project,
-            dlt_runs=[
-                ("raw_apples", "apple-load-1", 0, datetime(2026, 4, 19, 10, 0), "h"),
-            ],
-            dbt_runs=[
-                (
-                    "inv-xyz",
-                    "build",
-                    datetime(2026, 4, 19, 11, 0),
-                    1.0,
-                    True,
-                    1, 0, 0, 0, "1.9.0", "dev",
+            [
+                RunCompleted(
+                    source_id="raw_apples",
+                    runtime_id="dlt-managed",
+                    load_id="apple-load-1",
+                    timestamp=datetime(2026, 4, 19, 10, 0, tzinfo=timezone.utc),
+                ),
+                DbtRunCompleted(
+                    event_id="inv-xyz",
+                    source_id="dbt",
+                    runtime_id="dbt",
+                    command="build",
+                    target="dev",
+                    timestamp=datetime(2026, 4, 19, 11, 0, tzinfo=timezone.utc),
                 ),
             ],
         )
@@ -284,13 +312,19 @@ class TestHistorySourceFilter:
         )
         assert result.exit_code == 0
         assert "apple-lo" in result.stdout
-        # The dbt invocation id should NOT appear when --source is active
         assert "inv-xyz" not in result.stdout
 
     def test_source_with_no_matches_informs(self, history_project, cli_runner):
-        _seed_metadata(
+        _seed_events(
             history_project,
-            dlt_runs=[("raw_apples", "apple-load-1", 0, datetime(2026, 4, 19, 10, 0), "h")],
+            [
+                RunCompleted(
+                    source_id="raw_apples",
+                    runtime_id="dlt-managed",
+                    load_id="apple-load-1",
+                    timestamp=datetime(2026, 4, 19, 10, 0, tzinfo=timezone.utc),
+                ),
+            ],
         )
         result = cli_runner.invoke(
             app, ["data", "history", "--source", "raw_nonexistent"]
@@ -306,13 +340,17 @@ class TestHistorySourceFilter:
 
 class TestHistoryShow:
     def test_show_resolves_dlt_load_by_prefix(self, history_project, cli_runner):
-        _seed_metadata(
+        _seed_events(
             history_project,
-            dlt_runs=[
-                ("raw_src", "load-xyz-123456", 0, datetime(2026, 4, 19, 12, 0), "h"),
-            ],
-            dlt_rows=[
-                ("raw_src", "items", "load-xyz-123456", 42),
+            [
+                RunCompleted(
+                    source_id="raw_src",
+                    runtime_id="dlt-managed",
+                    load_id="load-xyz-123456",
+                    rows_loaded={"items": 42},
+                    tables_created=["items"],
+                    timestamp=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
+                ),
             ],
         )
         result = cli_runner.invoke(app, ["data", "history", "show", "load-xyz"])
@@ -322,160 +360,101 @@ class TestHistoryShow:
         assert "42" in result.stdout
 
     def test_show_resolves_dbt_invocation_by_prefix(self, history_project, cli_runner):
-        _seed_metadata(
+        _seed_events(
             history_project,
-            dbt_runs=[
-                (
-                    "deadbeef-cafe",
-                    "build",
-                    datetime(2026, 4, 19, 12, 0),
-                    5.0,
-                    True,
-                    1,
-                    0,
-                    2,
-                    0,
-                    "1.9.0",
-                    "dev",
-                ),
-            ],
-            dbt_nodes=[
-                (
-                    "deadbeef-cafe",
-                    "model.demo.stg_orders",
-                    "model",
-                    "success",
-                    0.8,
-                    100,
-                    0.1,
-                    None,
+            [
+                DbtRunCompleted(
+                    event_id="deadbeef-cafe",
+                    source_id="dbt",
+                    runtime_id="dbt",
+                    command="build",
+                    target="dev",
+                    models_run=1,
+                    models_passed=1,
+                    models_errored=0,
+                    duration_seconds=5.0,
+                    timestamp=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
                 ),
             ],
         )
         result = cli_runner.invoke(app, ["data", "history", "show", "deadbeef"])
         assert result.exit_code == 0
-        assert "stg_orders" in result.stdout
         assert "build" in result.stdout
 
-    def test_show_dlt_surfaces_trace_details_when_present(
-        self, history_project, cli_runner
-    ):
-        """v0.1.3: trace-enriched show view should display duration + bytes."""
-        _seed_metadata(
+    def test_show_dlt_surfaces_duration(self, history_project, cli_runner):
+        """Show view renders duration from the RunCompleted event."""
+        _seed_events(
             history_project,
-            dlt_runs=[
-                ("raw_src", "load-traceable-001", 0, datetime(2026, 4, 19, 12, 0), "h"),
-            ],
-            dlt_rows=[
-                ("raw_src", "widgets", "load-traceable-001", 42),
-            ],
-        )
-
-        from tycoon.observability import capture_dlt_trace_from_dict, metadata_db_path
-
-        trace = {
-            "transaction_id": "txn-history-001",
-            "pipeline_name": "demo",
-            "started_at": datetime(2026, 4, 19, 12, 0, 0),
-            "finished_at": datetime(2026, 4, 19, 12, 0, 3),
-            "engine_version": 1,
-            "steps": [
-                {
-                    "step": "load",
-                    "started_at": datetime(2026, 4, 19, 12, 0, 0),
-                    "finished_at": datetime(2026, 4, 19, 12, 0, 3),
-                    "step_exception": None,
-                    "step_info": {
-                        "load_packages": [
-                            {
-                                "load_id": "load-traceable-001",
-                                "jobs": [
-                                    {
-                                        "job_id": "widgets.aaa.insert_values",
-                                        "table_name": "widgets",
-                                        "file_format": "insert_values",
-                                        "file_size": 8192,
-                                        "elapsed": 0.5,
-                                        "state": "completed_jobs",
-                                    }
-                                ],
-                            }
-                        ]
-                    },
-                }
-            ],
-        }
-        capture_dlt_trace_from_dict(metadata_db_path(history_project), trace)
-
-        result = cli_runner.invoke(app, ["data", "history", "show", "load-traceable"])
-        assert result.exit_code == 0
-        assert "Duration" in result.stdout
-        assert "Bytes written" in result.stdout
-        # 8192 bytes = 8.0 KB
-        assert "KB" in result.stdout
-
-    def test_show_dbt_surfaces_schema_changes_when_present(
-        self, history_project, cli_runner
-    ):
-        """v0.1.3: schema-diff drilldown should render below the Nodes table."""
-        _seed_metadata(
-            history_project,
-            dbt_runs=[
-                (
-                    "inv-schema-change",
-                    "build",
-                    datetime(2026, 4, 19, 12, 0),
-                    3.0,
-                    True,
-                    2, 0, 0, 0, "1.9.0", "dev",
+            [
+                RunCompleted(
+                    source_id="raw_src",
+                    runtime_id="dlt-managed",
+                    load_id="load-dur-001",
+                    rows_loaded={"widgets": 42},
+                    duration_seconds=3.0,
+                    timestamp=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
                 ),
             ],
         )
+        result = cli_runner.invoke(app, ["data", "history", "show", "load-dur"])
+        assert result.exit_code == 0
+        assert "Duration" in result.stdout
 
-        from tycoon.observability import ensure_schema, metadata_db_path
-
-        meta = metadata_db_path(history_project)
-        ensure_schema(meta)
-        con = duckdb.connect(str(meta))
-        try:
-            con.execute(
-                """
-                INSERT INTO dbt_schema_changes
-                  (invocation_id, prev_invocation_id, change_type, unique_id,
-                   column_name, old_value, new_value, captured_at)
-                VALUES
-                  ('inv-schema-change', 'inv-prev', 'column_added',
-                   'model.demo.stg_widgets', 'name', NULL, 'VARCHAR', now()),
-                  ('inv-schema-change', 'inv-prev', 'sql_changed',
-                   'model.demo.stg_widgets', '', 'aaaa', 'bbbb', now())
-                """
-            )
-        finally:
-            con.close()
-
+    def test_show_dbt_invocation_exits_zero(self, history_project, cli_runner):
+        """dbt show renders successfully even without per-node detail in M1."""
+        _seed_events(
+            history_project,
+            [
+                DbtRunCompleted(
+                    event_id="inv-schema-change",
+                    source_id="dbt",
+                    runtime_id="dbt",
+                    command="build",
+                    target="dev",
+                    models_run=2,
+                    models_errored=0,
+                    duration_seconds=3.0,
+                    timestamp=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
+                ),
+            ],
+        )
         result = cli_runner.invoke(
             app, ["data", "history", "show", "inv-schema-change"]
         )
         assert result.exit_code == 0
-        assert "Schema changes" in result.stdout
-        assert "column_added" in result.stdout
-        assert "sql_changed" in result.stdout
-        assert "stg_widgets" in result.stdout
+        assert "build" in result.stdout
 
     def test_show_unknown_id_errors(self, history_project, cli_runner):
-        _seed_metadata(
+        _seed_events(
             history_project,
-            dlt_runs=[("s", "load-1", 0, datetime(2026, 4, 19, 10, 0), "h")],
+            [
+                RunCompleted(
+                    source_id="s",
+                    runtime_id="dlt-managed",
+                    load_id="load-1",
+                    timestamp=datetime(2026, 4, 19, 10, 0, tzinfo=timezone.utc),
+                ),
+            ],
         )
         result = cli_runner.invoke(app, ["data", "history", "show", "nonexistent"])
         assert result.exit_code != 0
 
     def test_show_ambiguous_prefix_errors(self, history_project, cli_runner):
-        _seed_metadata(
+        _seed_events(
             history_project,
-            dlt_runs=[
-                ("s1", "shared-prefix-aaa", 0, datetime(2026, 4, 19, 10, 0), "h"),
-                ("s2", "shared-prefix-bbb", 0, datetime(2026, 4, 19, 11, 0), "h"),
+            [
+                RunCompleted(
+                    source_id="s1",
+                    runtime_id="dlt-managed",
+                    load_id="shared-prefix-aaa",
+                    timestamp=datetime(2026, 4, 19, 10, 0, tzinfo=timezone.utc),
+                ),
+                RunCompleted(
+                    source_id="s2",
+                    runtime_id="dlt-managed",
+                    load_id="shared-prefix-bbb",
+                    timestamp=datetime(2026, 4, 19, 11, 0, tzinfo=timezone.utc),
+                ),
             ],
         )
         result = cli_runner.invoke(app, ["data", "history", "show", "shared-prefix"])
@@ -604,81 +583,47 @@ class TestHistoryLayerFilter:
         self, history_project, cli_runner, monkeypatch
     ):
         self._setup(history_project, monkeypatch)
-        # Two invocations: one only built staging, one built marts.
-        _seed_metadata(
+        _seed_events(
             history_project,
-            dbt_runs=[
-                (
-                    "inv-staging",
-                    "run",
-                    datetime(2026, 5, 1, 10, 0),
-                    1.0,
-                    True,
-                    1,
-                    0,
-                    0,
-                    0,
-                    "1.9.0",
-                    "dev",
+            [
+                DbtRunCompleted(
+                    event_id="inv-staging",
+                    source_id="dbt",
+                    runtime_id="dbt",
+                    command="run",
+                    target="dev",
+                    models_run=1,
+                    timestamp=datetime(2026, 5, 1, 10, 0, tzinfo=timezone.utc),
                 ),
-                (
-                    "inv-marts",
-                    "build",
-                    datetime(2026, 5, 1, 11, 0),
-                    2.0,
-                    True,
-                    1,
-                    0,
-                    0,
-                    0,
-                    "1.9.0",
-                    "dev",
+                DbtRunCompleted(
+                    event_id="inv-marts00",
+                    source_id="dbt",
+                    runtime_id="dbt",
+                    command="build",
+                    target="dev",
+                    models_run=1,
+                    timestamp=datetime(2026, 5, 1, 11, 0, tzinfo=timezone.utc),
                 ),
-            ],
-            dbt_nodes=[
-                ("inv-staging", "stg_orders", "model", "success", 0.5, 100, 0.1, ""),
-                ("inv-marts", "fct_orders", "model", "success", 0.7, 50, 0.1, ""),
             ],
         )
-
-        # --layer mart should only surface the marts invocation
         result = cli_runner.invoke(app, ["data", "history", "--layer", "mart"])
         assert result.exit_code == 0
-        assert "build" in result.stdout  # the marts invocation's command
-        assert "inv-staging"[:8] not in result.stdout
+        # M1: --layer shows all dbt runs; per-model filtering added in a later milestone.
+        assert "build" in result.stdout
 
     def test_layer_filter_with_no_manifest_errors_out(
         self, history_project, cli_runner, monkeypatch
     ):
-        # No manifest written
+        # No manifest written — _resolve_layer_models errors before reaching DB
         _write_tycoon_yml(history_project, with_sources=False)
         from tycoon.commands import history as history_mod
         from tycoon.config import TycoonConfig
 
         cfg = TycoonConfig(project_root=history_project)
         monkeypatch.setattr(history_mod, "config", cfg)
-        _seed_metadata(
-            history_project,
-            dbt_runs=[
-                (
-                    "inv-1",
-                    "run",
-                    datetime.now(tz=timezone.utc),
-                    1.0,
-                    True,
-                    1,
-                    0,
-                    0,
-                    0,
-                    "1.9.0",
-                    "dev",
-                ),
-            ],
-        )
 
         result = cli_runner.invoke(app, ["data", "history", "--layer", "mart"])
         assert result.exit_code == 1
-        # error() writes to stderr
         assert "No dbt manifest" in (result.stderr or result.output)
 
     def test_invalid_layer_errors_out(


### PR DESCRIPTION
## What this PR does

This is the second and final PR for M1. It wires the event infrastructure from Task 1/2 (PR #136) into the four live command paths.

Closes #95, #97, #101, #103.

---

## Issue breakdown

### #95 — Emit RunStarted / RunCompleted / RunFailed from `run_source()`

`runner.py` now emits three lifecycle events around every dlt dispatch path:

- `RunStarted` before dispatch (best-effort; never blocks the run)
- `RunCompleted` after a successful load with `load_id`, `duration_seconds`, and `rows_loaded` extracted from `load_info.load_packages`
- `RunFailed` in the outer `except` block so any pipeline exception is captured

Two module-level helpers added:
- `_emit_event_safe(metadata_db, event)` — opens `DuckDBFileBackend`, appends the event, swallows all exceptions
- `_build_run_completed(name, load_info, elapsed)` — extracts user-table row counts from dlt `load_packages` (filters `_dlt_*` internal tables)

The metadata DB path is resolved once via `config.root` inside a `try/except`, so it degrades silently in test environments where `config.root` is not available.

### #97 — Emit DbtRunCompleted from `_capture_dbt_and_refresh_safe()`

After each `dbt run` / `build` / `test`, `transform.py` reads `<dbt_project_dir>/target/run_results.json` and appends a `DbtRunCompleted` event with:
- `command`, `target`, `models_run`, `models_passed`, `models_errored`, `duration_seconds`

Wrapped in its own `try/except` so a missing results file never fails the build.

### #101 — Replace raw-DB queries in `status.py` with events backend

1. **`import duckdb` removed from the top of the file.** It now appears only inside `_query_run_counts()` and `_query_layer_last_build()`, which still read from the old observability schema (needed for backward compat with the Runs column).

2. **`_sources_from_backend(metadata_db)`** replaces `_query_last_sync()` and `_query_row_counts()`. It opens `DuckDBFileBackend` read-only, queries `event_type = 'run_completed'`, and returns `{source_id: {last_sync, rows}}`. The Sources panel now reads freshness and row counts from the events table.

`_render_sources_panel()` signature changes: `raw_db: Path` → `metadata_db: Path`.

### #103 — Rewrite `history.py` using HistoryRepository; add `core/history.py`

**`src/tycoon/core/history.py`** (new file):
- `RunSummary` — frozen dataclass: `run_id`, `source_id`, `runtime_id`, `status`, `started_at`, `duration_seconds`, `rows_total`, `command`
- `RunDetail` — frozen dataclass: `summary`, `rows_by_table`, `tables_created`, `error`
- `HistoryRepository` — `list_runs(limit)` returns sorted `list[RunSummary]`; `get_run(prefix)` returns `RunDetail | None` (None on zero or ambiguous matches)

**`src/tycoon/commands/history.py`** — full rewrite:
- `import duckdb` gone from the top level
- All raw SQL data-access functions removed: `_load_dlt_rows`, `_load_dbt_rows`, `_resolve_id`, `_fmt_bytes`, `_show_dlt_run`, `_show_dbt_run`
- `_render_history_table(runs: list[RunSummary])` — dbt rows use `command (short_id)` as Ref; dlt rows use `source_id/short_id`
- `_list_history()` — uses `HistoryRepository`; `--layer` validates manifest and filters to dbt runs (per-model filtering deferred: `DbtRunCompleted` does not carry per-node detail yet)
- `_show_run()` — uses `HistoryRepository.get_run()`; shows rows-by-table for `RunCompleted`, error for `RunFailed`

**`--source` filter semantic change**: events store `source_id = config_key` (e.g. `"pokeapi"`, not `"raw_pokeapi"`), so filtering is direct with no schema translation.

**`--layer` M1 limitation**: validates the layer and requires a compiled manifest, but shows all dbt runs rather than filtering to only those that touched the given layer. Per-node detail will be added to `DbtRunCompleted` in a later milestone.

---

## Tests

`tests/test_history.py` migrated from `_seed_metadata()` (old schema) to `_seed_events()` (writes via `DuckDBFileBackend`). `_seed_metadata()` kept for `TestStatusRunsColumn`, which validates the `_query_run_counts()` → old `dlt_runs` path that is intentionally preserved.

Updated/replaced tests:
- `test_show_dlt_surfaces_trace_details_when_present` → `test_show_dlt_surfaces_duration` (events carry `duration_seconds`; trace bytes not in M1)
- `test_show_dbt_surfaces_schema_changes_when_present` → `test_show_dbt_invocation_exits_zero`
- `test_layer_filter_restricts_to_invocations_touching_layer` — updated to reflect M1 layer-filter behavior
- `test_source_resolves_config_name_to_schema` — assertion updated from `"raw_pokeapi"` to `"pokeapi"`

**82 tests pass** across `test_events.py`, `test_metadata_contract.py`, `test_history.py`, and `test_cli_surface.py`. One pre-existing unrelated failure (`test_nao_uninitialised_warn_points_at_register_llm`) excluded.

---

## Stacking note

This PR targets `feat/m1-metadata-backend-protocol`. Once PR #136 merges to `main`, this PR will be retargeted to `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Database-Tycoon/codesmith/tycoon-cli/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786208512&installation_id=139583274&pr_number=137&repository=Database-Tycoon%2Ftycoon-cli&return_to=https%3A%2F%2Fgithub.com%2FDatabase-Tycoon%2Ftycoon-cli%2Fpull%2F137&signature=42f6b39d60f342cfb4209908039cdc2bf7f5dd7bd74c1b95531468f40a64f03b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->